### PR TITLE
Main

### DIFF
--- a/Sources/iOS-BLE-Library/Peripheral/Peripheral+Writer.swift
+++ b/Sources/iOS-BLE-Library/Peripheral/Peripheral+Writer.swift
@@ -208,9 +208,9 @@ private class WriteCharacteristicOperation: BasicOperation<Void> {
 			state = .finished
 			return
 		}
-
+        print(".............")
 		self.cancelable = writtenEventsPublisher.share()
-			.filter { $0.0.uuid == self.characteristic.uuid }
+            .filter { $0.0.uuid == self.characteristic.uuid  && $0.0.service?.uuid == self.characteristic.service?.uuid }
 			.first()
 			.tryMap { v in
 				if let e = v.1 {
@@ -260,7 +260,7 @@ private class ReadCharacteristicOperation: BasicOperation<Data?> {
 		}
 
 		self.cancelable = updateEventPublisher.share()
-			.filter { $0.0.uuid == self.characteristic.uuid }
+            .filter { $0.0.uuid == self.characteristic.uuid  && $0.0.service?.uuid == self.characteristic.service?.uuid }
 			.first()
 			.tryMap { v in
 				if let e = v.1 {
@@ -311,7 +311,11 @@ private class WriteDescriptorOperation: BasicOperation<Void> {
         }
 
         self.cancelable = writtenEventsPublisher.share()
-            .filter { $0.0.uuid == self.descriptor.uuid && $0.0.characteristic?.uuid == self.descriptor.characteristic?.uuid }
+            .filter {
+                $0.0.uuid == self.descriptor.uuid &&
+                $0.0.characteristic?.uuid == self.descriptor.characteristic?.uuid &&
+                $0.0.characteristic?.service?.uuid == self.descriptor.characteristic?.service?.uuid
+            }
             .first()
             .tryMap { v in
                 if let e = v.1 {
@@ -361,7 +365,10 @@ private class ReadDescriptorOperation: BasicOperation<Any?> {
         }
 
         self.cancelable = updateEventPublisher.share()
-            .filter { $0.0.uuid == self.descriptor.uuid && $0.0.characteristic?.uuid == self.descriptor.characteristic?.uuid }
+            .filter { $0.0.uuid == self.descriptor.uuid &&
+                $0.0.characteristic?.uuid == self.descriptor.characteristic?.uuid &&
+                $0.0.characteristic?.service?.uuid == self.descriptor.characteristic?.service?.uuid
+            }
             .first()
             .tryMap { v in
                 if let e = v.1 {

--- a/Sources/iOS-BLE-Library/Peripheral/Peripheral.swift
+++ b/Sources/iOS-BLE-Library/Peripheral/Peripheral.swift
@@ -258,7 +258,8 @@ extension Peripheral {
         
 		return peripheralDelegate.discoveredDescriptorsSubject
 			.filter {
-                $0.value.0.uuid == characteristic.uuid
+                $0.value.0.uuid == characteristic.uuid 
+                
 			}
             .first(where: { $0.id == id })
 			.tryCompactMap { result throws -> [CBDescriptor]? in
@@ -295,7 +296,10 @@ extension Peripheral {
     public func listenValues(for characteristic: CBCharacteristic) -> AnyPublisher<Data, Error>
     {
         return peripheralDelegate.updatedCharacteristicValuesSubject
-            .filter { $0.0.uuid == characteristic.uuid }
+            .filter {
+                $0.0.uuid == characteristic.uuid &&
+                $0.0.service?.uuid == characteristic.service?.uuid
+            }
             .tryCompactMap { (ch, err) in
                 if let err {
                     throw err
@@ -326,8 +330,16 @@ extension Peripheral {
 	public func writeValueWithResponse(_ data: Data, for characteristic: CBCharacteristic)
 		-> AnyPublisher<Void, Error>
 	{
+        print("......")
 		return peripheralDelegate.writtenCharacteristicValuesSubject
-			.first(where: { $0.0.uuid == characteristic.uuid })
+            .map{ result in
+                print("receive ...")
+                return result
+            }
+            .first(where: {
+                $0.0.uuid == characteristic.uuid &&
+                $0.0.service?.uuid == characteristic.service?.uuid
+            })
 			.tryMap { result in
 				if let e = result.1 {
 					throw e
@@ -380,7 +392,10 @@ extension Peripheral {
 		}
 
 		return peripheralDelegate.notificationStateSubject
-			.first { $0.0.uuid == characteristic.uuid }
+			.first {
+                $0.0.uuid == characteristic.uuid &&
+                $0.0.service?.uuid == characteristic.service?.uuid
+            }
 			.tryMap { result in
 				if let e = result.1 {
 					throw e


### PR DESCRIPTION
In the initial logic, only the UUID of a Bluetooth characteristic was used to link an action to its response. This led to issues when, for example, two characteristics with the same UUID existed in different services. For instance, a temperature sensor in the CPU service and another temperature sensor in a different service would share the same temperature reporting functionality. It’s logical that they would have the same UUID, but this setup could cause conflicts.