### PR TITLE
Enhance filtering logic to include service UUID checks

### DIFF
--- a/Sources/iOS-BLE-Library/Peripheral/Peripheral+Writer.swift
+++ b/Sources/iOS-BLE-Library/Peripheral/Peripheral+Writer.swift
@@ -208,7 +208,6 @@ private class WriteCharacteristicOperation: BasicOperation<Void> {
 			state = .finished
 			return
 		}
-        print(".............")
 		self.cancelable = writtenEventsPublisher.share()
             .filter { $0.0.uuid == self.characteristic.uuid  && $0.0.service?.uuid == self.characteristic.service?.uuid }
 			.first()

--- a/Sources/iOS-BLE-Library/Peripheral/Peripheral+Writer.swift
+++ b/Sources/iOS-BLE-Library/Peripheral/Peripheral+Writer.swift
@@ -49,30 +49,30 @@ extension Peripheral {
 			super.init(peripheral: peripheral)
 		}
 	}
-    
-    class DescriptorWriter: OperationQueue {
-        let writtenEventsPublisher: AnyPublisher<(CBDescriptor, Error?), Never>
+	
+	class DescriptorWriter: OperationQueue {
+		let writtenEventsPublisher: AnyPublisher<(CBDescriptor, Error?), Never>
 
-        init(
-            writtenEventsPublisher: AnyPublisher<(CBDescriptor, Error?), Never>,
-            peripheral: CBPeripheral
-        ) {
-            self.writtenEventsPublisher = writtenEventsPublisher
-            super.init(peripheral: peripheral)
-        }
-    }
-    
-    class DescriptorReader: OperationQueue {
-        let updateEventsPublisher: AnyPublisher<(CBDescriptor, Error?), Never>
+		init(
+			writtenEventsPublisher: AnyPublisher<(CBDescriptor, Error?), Never>,
+			peripheral: CBPeripheral
+		) {
+			self.writtenEventsPublisher = writtenEventsPublisher
+			super.init(peripheral: peripheral)
+		}
+	}
+	
+	class DescriptorReader: OperationQueue {
+		let updateEventsPublisher: AnyPublisher<(CBDescriptor, Error?), Never>
 
-        init(
-            updateEventsPublisher: AnyPublisher<(CBDescriptor, Error?), Never>,
-            peripheral: CBPeripheral
-        ) {
-            self.updateEventsPublisher = updateEventsPublisher
-            super.init(peripheral: peripheral)
-        }
-    }
+		init(
+			updateEventsPublisher: AnyPublisher<(CBDescriptor, Error?), Never>,
+			peripheral: CBPeripheral
+		) {
+			self.updateEventsPublisher = updateEventsPublisher
+			super.init(peripheral: peripheral)
+		}
+	}
 }
 
 extension Peripheral.CharacteristicWriter {
@@ -104,32 +104,32 @@ extension Peripheral.CharacteristicReader {
 }
 
 extension Peripheral.DescriptorWriter {
-    func write(_ value: Data, to dsecriptor: CBDescriptor) -> Future<Void, Error> {
-        let operation = WriteDescriptorOperation(
-            data: value,
-            writtenEventsPublisher: writtenEventsPublisher,
-            descriptor: dsecriptor,
-            peripheral: peripheral
-        )
+	func write(_ value: Data, to dsecriptor: CBDescriptor) -> Future<Void, Error> {
+		let operation = WriteDescriptorOperation(
+			data: value,
+			writtenEventsPublisher: writtenEventsPublisher,
+			descriptor: dsecriptor,
+			peripheral: peripheral
+		)
 
-        queue.addOperation(operation)
+		queue.addOperation(operation)
 
-        return operation.future
-    }
+		return operation.future
+	}
 }
 
 extension Peripheral.DescriptorReader {
-    func readValue(from descriptor: CBDescriptor) -> Future<Any?, Error> {
-        let operation = ReadDescriptorOperation(
-            updateEventPublisher: updateEventsPublisher,
-            descriptor: descriptor,
-            peripheral: peripheral
-        )
+	func readValue(from descriptor: CBDescriptor) -> Future<Any?, Error> {
+		let operation = ReadDescriptorOperation(
+			updateEventPublisher: updateEventsPublisher,
+			descriptor: descriptor,
+			peripheral: peripheral
+		)
 
-        queue.addOperation(operation)
+		queue.addOperation(operation)
 
-        return operation.future
-    }
+		return operation.future
+	}
 }
 
 private class BasicOperation<T>: Operation {
@@ -209,7 +209,7 @@ private class WriteCharacteristicOperation: BasicOperation<Void> {
 			return
 		}
 		self.cancelable = writtenEventsPublisher.share()
-            .filter { $0.0.uuid == self.characteristic.uuid  && $0.0.service?.uuid == self.characteristic.service?.uuid }
+			.filter { $0.0.uuid == self.characteristic.uuid  && $0.0.service?.uuid == self.characteristic.service?.uuid }
 			.first()
 			.tryMap { v in
 				if let e = v.1 {
@@ -259,7 +259,7 @@ private class ReadCharacteristicOperation: BasicOperation<Data?> {
 		}
 
 		self.cancelable = updateEventPublisher.share()
-            .filter { $0.0.uuid == self.characteristic.uuid  && $0.0.service?.uuid == self.characteristic.service?.uuid }
+			.filter { $0.0.uuid == self.characteristic.uuid  && $0.0.service?.uuid == self.characteristic.service?.uuid }
 			.first()
 			.tryMap { v in
 				if let e = v.1 {
@@ -284,108 +284,108 @@ private class ReadCharacteristicOperation: BasicOperation<Data?> {
 
 private class WriteDescriptorOperation: BasicOperation<Void> {
 
-    let writtenEventsPublisher: AnyPublisher<(CBDescriptor, Error?), Never>
-    let descriptor: CBDescriptor
+	let writtenEventsPublisher: AnyPublisher<(CBDescriptor, Error?), Never>
+	let descriptor: CBDescriptor
 
-    let data: Data
+	let data: Data
 
-    init(
-        data: Data, writtenEventsPublisher: AnyPublisher<(CBDescriptor, Error?), Never>,
-        descriptor: CBDescriptor, peripheral: CBPeripheral
-    ) {
-        self.data = data
-        self.writtenEventsPublisher = writtenEventsPublisher
-        self.descriptor = descriptor
-        super.init(peripheral: peripheral)
-    }
+	init(
+		data: Data, writtenEventsPublisher: AnyPublisher<(CBDescriptor, Error?), Never>,
+		descriptor: CBDescriptor, peripheral: CBPeripheral
+	) {
+		self.data = data
+		self.writtenEventsPublisher = writtenEventsPublisher
+		self.descriptor = descriptor
+		super.init(peripheral: peripheral)
+	}
 
-    override func main() {
-        peripheral.writeValue(data, for: descriptor)
-    }
+	override func main() {
+		peripheral.writeValue(data, for: descriptor)
+	}
 
-    override func start() {
-        if isCancelled {
-            state = .finished
-            return
-        }
+	override func start() {
+		if isCancelled {
+			state = .finished
+			return
+		}
 
-        self.cancelable = writtenEventsPublisher.share()
-            .filter {
-                $0.0.uuid == self.descriptor.uuid &&
-                $0.0.characteristic?.uuid == self.descriptor.characteristic?.uuid &&
-                $0.0.characteristic?.service?.uuid == self.descriptor.characteristic?.service?.uuid
-            }
-            .first()
-            .tryMap { v in
-                if let e = v.1 {
-                    throw e
-                } else {
-                    return v.0
-                }
-            }
-            .sink { [unowned self] completion in
-                switch completion {
-                case .finished:
-                    self.promise?(.success(()))
-                case .failure(let e):
-                    self.promise?(.failure(e))
-                }
-                self.state = .finished
-            } receiveValue: { _ in
+		self.cancelable = writtenEventsPublisher.share()
+			.filter {
+				$0.0.uuid == self.descriptor.uuid &&
+				$0.0.characteristic?.uuid == self.descriptor.characteristic?.uuid &&
+				$0.0.characteristic?.service?.uuid == self.descriptor.characteristic?.service?.uuid
+			}
+			.first()
+			.tryMap { v in
+				if let e = v.1 {
+					throw e
+				} else {
+					return v.0
+				}
+			}
+			.sink { [unowned self] completion in
+				switch completion {
+				case .finished:
+					self.promise?(.success(()))
+				case .failure(let e):
+					self.promise?(.failure(e))
+				}
+				self.state = .finished
+			} receiveValue: { _ in
 
-            }
+			}
 
-        state = .executing
-        main()
-    }
+		state = .executing
+		main()
+	}
 }
 
 private class ReadDescriptorOperation: BasicOperation<Any?> {
-    let updateEventPublisher: AnyPublisher<(CBDescriptor, Error?), Never>
-    let descriptor: CBDescriptor
+	let updateEventPublisher: AnyPublisher<(CBDescriptor, Error?), Never>
+	let descriptor: CBDescriptor
 
-    init(
-        updateEventPublisher: AnyPublisher<(CBDescriptor, Error?), Never>,
-        descriptor: CBDescriptor, peripheral: CBPeripheral
-    ) {
-        self.updateEventPublisher = updateEventPublisher
-        self.descriptor = descriptor
-        super.init(peripheral: peripheral)
-    }
+	init(
+		updateEventPublisher: AnyPublisher<(CBDescriptor, Error?), Never>,
+		descriptor: CBDescriptor, peripheral: CBPeripheral
+	) {
+		self.updateEventPublisher = updateEventPublisher
+		self.descriptor = descriptor
+		super.init(peripheral: peripheral)
+	}
 
-    override func main() {
-        peripheral.readValue(for: descriptor)
-    }
+	override func main() {
+		peripheral.readValue(for: descriptor)
+	}
 
-    override func start() {
-        if isCancelled {
-            state = .finished
-            return
-        }
+	override func start() {
+		if isCancelled {
+			state = .finished
+			return
+		}
 
-        self.cancelable = updateEventPublisher.share()
-            .filter { $0.0.uuid == self.descriptor.uuid &&
-                $0.0.characteristic?.uuid == self.descriptor.characteristic?.uuid &&
-                $0.0.characteristic?.service?.uuid == self.descriptor.characteristic?.service?.uuid
-            }
-            .first()
-            .tryMap { v in
-                if let e = v.1 {
-                    throw e
-                } else {
-                    return v.0.value
-                }
-            }
-            .sink { [unowned self] completion in
-                if case .failure(let e) = completion {
-                    self.promise?(.failure(e))
-                }
-                self.state = .finished
-            } receiveValue: { v in
-                self.promise?(.success(v))
-            }
+		self.cancelable = updateEventPublisher.share()
+			.filter { $0.0.uuid == self.descriptor.uuid &&
+				$0.0.characteristic?.uuid == self.descriptor.characteristic?.uuid &&
+				$0.0.characteristic?.service?.uuid == self.descriptor.characteristic?.service?.uuid
+			}
+			.first()
+			.tryMap { v in
+				if let e = v.1 {
+					throw e
+				} else {
+					return v.0.value
+				}
+			}
+			.sink { [unowned self] completion in
+				if case .failure(let e) = completion {
+					self.promise?(.failure(e))
+				}
+				self.state = .finished
+			} receiveValue: { v in
+				self.promise?(.success(v))
+			}
 
-        state = .executing
-        main()
-    }
+		state = .executing
+		main()
+	}
 }

--- a/Sources/iOS-BLE-Library/Peripheral/Peripheral+Writer.swift
+++ b/Sources/iOS-BLE-Library/Peripheral/Peripheral+Writer.swift
@@ -210,7 +210,7 @@ private class WriteCharacteristicOperation: BasicOperation<Void> {
 		}
 
 		self.cancelable = writtenEventsPublisher.share()
-			.filter { $0.0.uuid == self.characteristic.uuid && $0.0.service?.uuid == self.characteristic.service?.uuid  }
+			.filter { $0.0.uuid == self.characteristic.uuid && $0.0.service?.uuid == self.characteristic.service?.uuid }
 			.first()
 			.tryMap { v in
 				if let e = v.1 {
@@ -311,7 +311,7 @@ private class WriteDescriptorOperation: BasicOperation<Void> {
         }
 
         self.cancelable = writtenEventsPublisher.share()
-            .filter { $0.0.uuid == self.descriptor.uuid && $0.0.characteristic?.uuid == self.descriptor.characteristic?.uuid && $0.0.characteristic?.uuid == self.descriptor.characteristic?.uuid && $0.0.characteristic?.service?.uuid == self.descriptor.characteristic?.service?.uuid}
+            .filter { $0.0.uuid == self.descriptor.uuid && $0.0.characteristic?.uuid == self.descriptor.characteristic?.uuid && $0.0.characteristic?.uuid == self.descriptor.characteristic?.uuid && $0.0.characteristic?.service?.uuid == self.descriptor.characteristic?.service?.uuid }
             .first()
             .tryMap { v in
                 if let e = v.1 {

--- a/Sources/iOS-BLE-Library/Peripheral/Peripheral+Writer.swift
+++ b/Sources/iOS-BLE-Library/Peripheral/Peripheral+Writer.swift
@@ -208,9 +208,9 @@ private class WriteCharacteristicOperation: BasicOperation<Void> {
 			state = .finished
 			return
 		}
-
+        print(".............")
 		self.cancelable = writtenEventsPublisher.share()
-			.filter { $0.0.uuid == self.characteristic.uuid }
+            .filter { $0.0.uuid == self.characteristic.uuid  && $0.0.service?.uuid == self.characteristic.service?.uuid }
 			.first()
 			.tryMap { v in
 				if let e = v.1 {
@@ -260,7 +260,7 @@ private class ReadCharacteristicOperation: BasicOperation<Data?> {
 		}
 
 		self.cancelable = updateEventPublisher.share()
-			.filter { $0.0.uuid == self.characteristic.uuid }
+            .filter { $0.0.uuid == self.characteristic.uuid  && $0.0.service?.uuid == self.characteristic.service?.uuid }
 			.first()
 			.tryMap { v in
 				if let e = v.1 {
@@ -311,7 +311,11 @@ private class WriteDescriptorOperation: BasicOperation<Void> {
         }
 
         self.cancelable = writtenEventsPublisher.share()
-            .filter { $0.0.uuid == self.descriptor.uuid && $0.0.characteristic?.uuid == self.descriptor.characteristic?.uuid }
+            .filter {
+                $0.0.uuid == self.descriptor.uuid &&
+                $0.0.characteristic?.uuid == self.descriptor.characteristic?.uuid &&
+                $0.0.characteristic?.service?.uuid == self.descriptor.characteristic?.service?.uuid
+            }
             .first()
             .tryMap { v in
                 if let e = v.1 {
@@ -361,7 +365,10 @@ private class ReadDescriptorOperation: BasicOperation<Any?> {
         }
 
         self.cancelable = updateEventPublisher.share()
-            .filter { $0.0.uuid == self.descriptor.uuid && $0.0.characteristic?.uuid == self.descriptor.characteristic?.uuid }
+            .filter { $0.0.uuid == self.descriptor.uuid &&
+                $0.0.characteristic?.uuid == self.descriptor.characteristic?.uuid &&
+                $0.0.characteristic?.service?.uuid == self.descriptor.characteristic?.service?.uuid
+            }
             .first()
             .tryMap { v in
                 if let e = v.1 {

--- a/Sources/iOS-BLE-Library/Peripheral/Peripheral+Writer.swift
+++ b/Sources/iOS-BLE-Library/Peripheral/Peripheral+Writer.swift
@@ -49,30 +49,30 @@ extension Peripheral {
 			super.init(peripheral: peripheral)
 		}
 	}
-	
-	class DescriptorWriter: OperationQueue {
-		let writtenEventsPublisher: AnyPublisher<(CBDescriptor, Error?), Never>
+    
+    class DescriptorWriter: OperationQueue {
+        let writtenEventsPublisher: AnyPublisher<(CBDescriptor, Error?), Never>
 
-		init(
-			writtenEventsPublisher: AnyPublisher<(CBDescriptor, Error?), Never>,
-			peripheral: CBPeripheral
-		) {
-			self.writtenEventsPublisher = writtenEventsPublisher
-			super.init(peripheral: peripheral)
-		}
-	}
-	
-	class DescriptorReader: OperationQueue {
-		let updateEventsPublisher: AnyPublisher<(CBDescriptor, Error?), Never>
+        init(
+            writtenEventsPublisher: AnyPublisher<(CBDescriptor, Error?), Never>,
+            peripheral: CBPeripheral
+        ) {
+            self.writtenEventsPublisher = writtenEventsPublisher
+            super.init(peripheral: peripheral)
+        }
+    }
+    
+    class DescriptorReader: OperationQueue {
+        let updateEventsPublisher: AnyPublisher<(CBDescriptor, Error?), Never>
 
-		init(
-			updateEventsPublisher: AnyPublisher<(CBDescriptor, Error?), Never>,
-			peripheral: CBPeripheral
-		) {
-			self.updateEventsPublisher = updateEventsPublisher
-			super.init(peripheral: peripheral)
-		}
-	}
+        init(
+            updateEventsPublisher: AnyPublisher<(CBDescriptor, Error?), Never>,
+            peripheral: CBPeripheral
+        ) {
+            self.updateEventsPublisher = updateEventsPublisher
+            super.init(peripheral: peripheral)
+        }
+    }
 }
 
 extension Peripheral.CharacteristicWriter {
@@ -104,32 +104,32 @@ extension Peripheral.CharacteristicReader {
 }
 
 extension Peripheral.DescriptorWriter {
-	func write(_ value: Data, to dsecriptor: CBDescriptor) -> Future<Void, Error> {
-		let operation = WriteDescriptorOperation(
-			data: value,
-			writtenEventsPublisher: writtenEventsPublisher,
-			descriptor: dsecriptor,
-			peripheral: peripheral
-		)
+    func write(_ value: Data, to dsecriptor: CBDescriptor) -> Future<Void, Error> {
+        let operation = WriteDescriptorOperation(
+            data: value,
+            writtenEventsPublisher: writtenEventsPublisher,
+            descriptor: dsecriptor,
+            peripheral: peripheral
+        )
 
-		queue.addOperation(operation)
+        queue.addOperation(operation)
 
-		return operation.future
-	}
+        return operation.future
+    }
 }
 
 extension Peripheral.DescriptorReader {
-	func readValue(from descriptor: CBDescriptor) -> Future<Any?, Error> {
-		let operation = ReadDescriptorOperation(
-			updateEventPublisher: updateEventsPublisher,
-			descriptor: descriptor,
-			peripheral: peripheral
-		)
+    func readValue(from descriptor: CBDescriptor) -> Future<Any?, Error> {
+        let operation = ReadDescriptorOperation(
+            updateEventPublisher: updateEventsPublisher,
+            descriptor: descriptor,
+            peripheral: peripheral
+        )
 
-		queue.addOperation(operation)
+        queue.addOperation(operation)
 
-		return operation.future
-	}
+        return operation.future
+    }
 }
 
 private class BasicOperation<T>: Operation {
@@ -208,8 +208,9 @@ private class WriteCharacteristicOperation: BasicOperation<Void> {
 			state = .finished
 			return
 		}
+
 		self.cancelable = writtenEventsPublisher.share()
-			.filter { $0.0.uuid == self.characteristic.uuid  && $0.0.service?.uuid == self.characteristic.service?.uuid }
+			.filter { $0.0.uuid == self.characteristic.uuid && $0.0.service?.uuid == self.characteristic.service?.uuid  }
 			.first()
 			.tryMap { v in
 				if let e = v.1 {
@@ -259,7 +260,7 @@ private class ReadCharacteristicOperation: BasicOperation<Data?> {
 		}
 
 		self.cancelable = updateEventPublisher.share()
-			.filter { $0.0.uuid == self.characteristic.uuid  && $0.0.service?.uuid == self.characteristic.service?.uuid }
+			.filter { $0.0.uuid == self.characteristic.uuid && $0.0.service?.uuid == self.characteristic.service?.uuid }
 			.first()
 			.tryMap { v in
 				if let e = v.1 {
@@ -284,108 +285,101 @@ private class ReadCharacteristicOperation: BasicOperation<Data?> {
 
 private class WriteDescriptorOperation: BasicOperation<Void> {
 
-	let writtenEventsPublisher: AnyPublisher<(CBDescriptor, Error?), Never>
-	let descriptor: CBDescriptor
+    let writtenEventsPublisher: AnyPublisher<(CBDescriptor, Error?), Never>
+    let descriptor: CBDescriptor
 
-	let data: Data
+    let data: Data
 
-	init(
-		data: Data, writtenEventsPublisher: AnyPublisher<(CBDescriptor, Error?), Never>,
-		descriptor: CBDescriptor, peripheral: CBPeripheral
-	) {
-		self.data = data
-		self.writtenEventsPublisher = writtenEventsPublisher
-		self.descriptor = descriptor
-		super.init(peripheral: peripheral)
-	}
+    init(
+        data: Data, writtenEventsPublisher: AnyPublisher<(CBDescriptor, Error?), Never>,
+        descriptor: CBDescriptor, peripheral: CBPeripheral
+    ) {
+        self.data = data
+        self.writtenEventsPublisher = writtenEventsPublisher
+        self.descriptor = descriptor
+        super.init(peripheral: peripheral)
+    }
 
-	override func main() {
-		peripheral.writeValue(data, for: descriptor)
-	}
+    override func main() {
+        peripheral.writeValue(data, for: descriptor)
+    }
 
-	override func start() {
-		if isCancelled {
-			state = .finished
-			return
-		}
+    override func start() {
+        if isCancelled {
+            state = .finished
+            return
+        }
 
-		self.cancelable = writtenEventsPublisher.share()
-			.filter {
-				$0.0.uuid == self.descriptor.uuid &&
-				$0.0.characteristic?.uuid == self.descriptor.characteristic?.uuid &&
-				$0.0.characteristic?.service?.uuid == self.descriptor.characteristic?.service?.uuid
-			}
-			.first()
-			.tryMap { v in
-				if let e = v.1 {
-					throw e
-				} else {
-					return v.0
-				}
-			}
-			.sink { [unowned self] completion in
-				switch completion {
-				case .finished:
-					self.promise?(.success(()))
-				case .failure(let e):
-					self.promise?(.failure(e))
-				}
-				self.state = .finished
-			} receiveValue: { _ in
+        self.cancelable = writtenEventsPublisher.share()
+            .filter { $0.0.uuid == self.descriptor.uuid && $0.0.characteristic?.uuid == self.descriptor.characteristic?.uuid && $0.0.characteristic?.uuid == self.descriptor.characteristic?.uuid && $0.0.characteristic?.service?.uuid == self.descriptor.characteristic?.service?.uuid}
+            .first()
+            .tryMap { v in
+                if let e = v.1 {
+                    throw e
+                } else {
+                    return v.0
+                }
+            }
+            .sink { [unowned self] completion in
+                switch completion {
+                case .finished:
+                    self.promise?(.success(()))
+                case .failure(let e):
+                    self.promise?(.failure(e))
+                }
+                self.state = .finished
+            } receiveValue: { _ in
 
-			}
+            }
 
-		state = .executing
-		main()
-	}
+        state = .executing
+        main()
+    }
 }
 
 private class ReadDescriptorOperation: BasicOperation<Any?> {
-	let updateEventPublisher: AnyPublisher<(CBDescriptor, Error?), Never>
-	let descriptor: CBDescriptor
+    let updateEventPublisher: AnyPublisher<(CBDescriptor, Error?), Never>
+    let descriptor: CBDescriptor
 
-	init(
-		updateEventPublisher: AnyPublisher<(CBDescriptor, Error?), Never>,
-		descriptor: CBDescriptor, peripheral: CBPeripheral
-	) {
-		self.updateEventPublisher = updateEventPublisher
-		self.descriptor = descriptor
-		super.init(peripheral: peripheral)
-	}
+    init(
+        updateEventPublisher: AnyPublisher<(CBDescriptor, Error?), Never>,
+        descriptor: CBDescriptor, peripheral: CBPeripheral
+    ) {
+        self.updateEventPublisher = updateEventPublisher
+        self.descriptor = descriptor
+        super.init(peripheral: peripheral)
+    }
 
-	override func main() {
-		peripheral.readValue(for: descriptor)
-	}
+    override func main() {
+        peripheral.readValue(for: descriptor)
+    }
 
-	override func start() {
-		if isCancelled {
-			state = .finished
-			return
-		}
+    override func start() {
+        if isCancelled {
+            state = .finished
+            return
+        }
 
-		self.cancelable = updateEventPublisher.share()
-			.filter { $0.0.uuid == self.descriptor.uuid &&
-				$0.0.characteristic?.uuid == self.descriptor.characteristic?.uuid &&
-				$0.0.characteristic?.service?.uuid == self.descriptor.characteristic?.service?.uuid
-			}
-			.first()
-			.tryMap { v in
-				if let e = v.1 {
-					throw e
-				} else {
-					return v.0.value
-				}
-			}
-			.sink { [unowned self] completion in
-				if case .failure(let e) = completion {
-					self.promise?(.failure(e))
-				}
-				self.state = .finished
-			} receiveValue: { v in
-				self.promise?(.success(v))
-			}
+        self.cancelable = updateEventPublisher.share()
+            .filter { $0.0.uuid == self.descriptor.uuid && $0.0.characteristic?.uuid == self.descriptor.characteristic?.uuid &&	$0.0.characteristic?.uuid == self.descriptor.characteristic?.uuid && $0.0.characteristic?.service?.uuid == self.descriptor.characteristic?.service?.uuid }
+            .first()
+            .tryMap { v in
+                if let e = v.1 {
+                    throw e
+                } else {
+                    return v.0.value
+                }
+            }
+            .sink { [unowned self] completion in
+                if case .failure(let e) = completion {
+                    self.promise?(.failure(e))
+                }
+                self.state = .finished
+            } receiveValue: { v in
+                self.promise?(.success(v))
+            }
 
-		state = .executing
-		main()
-	}
+        state = .executing
+        main()
+    }
 }

--- a/Sources/iOS-BLE-Library/Peripheral/Peripheral.swift
+++ b/Sources/iOS-BLE-Library/Peripheral/Peripheral.swift
@@ -330,16 +330,14 @@ extension Peripheral {
 	public func writeValueWithResponse(_ data: Data, for characteristic: CBCharacteristic)
 		-> AnyPublisher<Void, Error>
 	{
-        print("......")
 		return peripheralDelegate.writtenCharacteristicValuesSubject
-            .map{ result in
-                print("receive ...")
-                return result
-            }
-            .first(where: {
-                $0.0.uuid == characteristic.uuid &&
-                $0.0.service?.uuid == characteristic.service?.uuid
-            })
+			.map{ result in
+				return result
+			}
+			.first(where: {
+				$0.0.uuid == characteristic.uuid &&
+				$0.0.service?.uuid == characteristic.service?.uuid
+			})
 			.tryMap { result in
 				if let e = result.1 {
 					throw e

--- a/Sources/iOS-BLE-Library/Peripheral/Peripheral.swift
+++ b/Sources/iOS-BLE-Library/Peripheral/Peripheral.swift
@@ -26,8 +26,8 @@ private class NativeObserver: Observer {
 
 	private weak var publisher: CurrentValueSubject<CBPeripheralState, Never>!
 	private var observation: NSKeyValueObservation?
-    
-    let l = L(category: "peripheral")
+	
+	let l = L(category: "peripheral")
 
 	init(
 		peripheral: CoreBluetooth.CBPeripheral,
@@ -41,9 +41,9 @@ private class NativeObserver: Observer {
 	override func setup() {
 		observation = peripheral.observe(\.state, options: [.new]) {
 			[weak self] _, change in
-            // TODO: Check threads
-            guard let self else { return }
-            self.publisher.send(self.peripheral.state)
+			// TODO: Check threads
+			guard let self else { return }
+			self.publisher.send(self.peripheral.state)
 		}
 	}
 }
@@ -53,36 +53,36 @@ private class NativeObserver: Observer {
 //CG_WITH
 /*
  private class MockObserver: Observer {
-     @objc private var peripheral: CBMPeripheralMock
+	 @objc private var peripheral: CBMPeripheralMock
 
-     private weak var publisher: CurrentValueSubject<CBPeripheralState, Never>!
-     private var observation: NSKeyValueObservation?
+	 private weak var publisher: CurrentValueSubject<CBPeripheralState, Never>!
+	 private var observation: NSKeyValueObservation?
 
-     init(peripheral: CBMPeripheralMock, publisher: CurrentValueSubject<CBPeripheralState, Never>) {
-         self.peripheral = peripheral
-         self.publisher = publisher
-         super.init()
-     }
+	 init(peripheral: CBMPeripheralMock, publisher: CurrentValueSubject<CBPeripheralState, Never>) {
+		 self.peripheral = peripheral
+		 self.publisher = publisher
+		 super.init()
+	 }
 
-     override func setup() {
-         observation = peripheral.observe(\.state, options: [.new]) { [weak self] _, change in
-             #warning("queue can be not only main")
-             DispatchQueue.main.async {
-                 guard let self else { return }
-                 self.publisher.send(self.peripheral.state)
-             }
-         }
-     }
+	 override func setup() {
+		 observation = peripheral.observe(\.state, options: [.new]) { [weak self] _, change in
+			 #warning("queue can be not only main")
+			 DispatchQueue.main.async {
+				 guard let self else { return }
+				 self.publisher.send(self.peripheral.state)
+			 }
+		 }
+	 }
  }
 */
 //CG_END
 
 
 public class Peripheral {
-    private var serviceDiscoveryQueue = Queue<UUID>()
-    
-    let l = L(category: #file)
-    
+	private var serviceDiscoveryQueue = Queue<UUID>()
+	
+	let l = L(category: #file)
+	
 	/// I'm Errr from Omicron Persei 8
 	public enum Err: Error {
 		case badDelegate
@@ -91,10 +91,10 @@ public class Peripheral {
 	/// The underlying CBPeripheral instance.
 	public let peripheral: CBPeripheral
 
-    // MARK: Identifying a Peripheralin page link
-    /// The name of the peripheral.
-    public var name: String? { peripheral.name }
-    
+	// MARK: Identifying a Peripheralin page link
+	/// The name of the peripheral.
+	public var name: String? { peripheral.name }
+	
 	/// The delegate for handling peripheral events.
 	public let peripheralDelegate: ReactivePeripheralDelegate
 
@@ -111,27 +111,27 @@ public class Peripheral {
 			.eraseToAnyPublisher(),
 		peripheral: peripheral
 	)
-    
-    private lazy var descriptorWriter = DescriptorWriter(
-        writtenEventsPublisher: self.peripheralDelegate.writtenDescriptorValuesSubject.eraseToAnyPublisher(),
-        peripheral: peripheral
-    )
-    
-    private lazy var descriptorReader = DescriptorReader(
-        updateEventsPublisher: self.peripheralDelegate.updatedDescriptorValuesSubject.eraseToAnyPublisher(),
-        peripheral: peripheral
-    )
+	
+	private lazy var descriptorWriter = DescriptorWriter(
+		writtenEventsPublisher: self.peripheralDelegate.writtenDescriptorValuesSubject.eraseToAnyPublisher(),
+		peripheral: peripheral
+	)
+	
+	private lazy var descriptorReader = DescriptorReader(
+		updateEventsPublisher: self.peripheralDelegate.updatedDescriptorValuesSubject.eraseToAnyPublisher(),
+		peripheral: peripheral
+	)
 
 	// TODO: Why don't we use default delegate?
 	/// Initializes a Peripheral instance.
-    ///
-    /// - Parameters:
-    ///   - peripheral: The CBPeripheral to manage.
-    ///   - delegate: The delegate for handling peripheral events.
+	///
+	/// - Parameters:
+	///   - peripheral: The CBPeripheral to manage.
+	///   - delegate: The delegate for handling peripheral events.
 	public init(peripheral: CBPeripheral, delegate: ReactivePeripheralDelegate = ReactivePeripheralDelegate()) {
 		self.peripheral = peripheral
 		self.peripheralDelegate = delegate
-        assert(peripheral.delegate == nil, "CBPeripheral's delegate should be nil, otherwise it can lead to problems")
+		assert(peripheral.delegate == nil, "CBPeripheral's delegate should be nil, otherwise it can lead to problems")
 		peripheral.delegate = delegate
 
 //CG_REPLACE
@@ -139,13 +139,13 @@ public class Peripheral {
 		observer.setup()
 //CG_WITH
 /*
-         if let p = peripheral as? CBMPeripheralNative {
-                     observer = NativeObserver(peripheral: p.peripheral, publisher: stateSubject)
-                     observer.setup()
-                 } else if let p = peripheral as? CBMPeripheralMock {
-                     observer = MockObserver(peripheral: p, publisher: stateSubject)
-                     observer.setup()
-                 }
+		 if let p = peripheral as? CBMPeripheralNative {
+					 observer = NativeObserver(peripheral: p.peripheral, publisher: stateSubject)
+					 observer.setup()
+				 } else if let p = peripheral as? CBMPeripheralMock {
+					 observer = MockObserver(peripheral: p, publisher: stateSubject)
+					 observer.setup()
+				 }
 */
 //CG_END
 	}
@@ -161,172 +161,172 @@ extension Peripheral {
 
 // MARK: - Discovering Servicesin page link
 extension Peripheral {
-    /// Discover services for the peripheral.
-    ///
-    /// - Parameter serviceUUIDs: An optional array of service UUIDs to filter the discovery results. If nil, all services will be discovered.
-    /// - Returns: A publisher emitting discovered services or an error.
-    public func discoverServices(serviceUUIDs: [CBUUID]?)
-    -> AnyPublisher<[CBService], Error>
-    {
-        let id = UUID()
-        
-        let allServices = peripheralDelegate.discoveredServicesSubject
-            .first(where: { $0.id == id } )
-            .tryCompactMap { result throws -> [CBService]? in
-                if let e = result.error {
-                    throw e
-                } else {
-                    return result.value
-                }
-            }
-            .first()
-        
-        return allServices.bluetooth {
-            let operation = IdentifiableOperation(id: id) {
-                self.peripheral.discoverServices(serviceUUIDs)
-                self.l.d("\(#function). operation ID: \(id)")
-                if let serviceUUIDs {
-                    for sid in serviceUUIDs {
-                        self.l.d("Services: \(sid)")
-                    }
-                } else {
-                    self.l.d("All services")
-                }
-            }
-            
-            self.peripheralDelegate.discoveredServicesQueue.addOperation(operation)
-        }
-        .autoconnect()
-        .eraseToAnyPublisher()
-    }
-    
-    /// Discovers the specified included services of a previously-discovered service.
-    public func discoverIncludedServices(_ includedServiceUUIDs: [CBUUID]?, for: CBService) -> AnyPublisher<[CBService], Error> {
-        fatalError()
-    }
-    
-    /// A list of a peripheral’s discovered services.
-    public var services: [CBService]? {
-        peripheral.services
-    }
+	/// Discover services for the peripheral.
+	///
+	/// - Parameter serviceUUIDs: An optional array of service UUIDs to filter the discovery results. If nil, all services will be discovered.
+	/// - Returns: A publisher emitting discovered services or an error.
+	public func discoverServices(serviceUUIDs: [CBUUID]?)
+	-> AnyPublisher<[CBService], Error>
+	{
+		let id = UUID()
+		
+		let allServices = peripheralDelegate.discoveredServicesSubject
+			.first(where: { $0.id == id } )
+			.tryCompactMap { result throws -> [CBService]? in
+				if let e = result.error {
+					throw e
+				} else {
+					return result.value
+				}
+			}
+			.first()
+		
+		return allServices.bluetooth {
+			let operation = IdentifiableOperation(id: id) {
+				self.peripheral.discoverServices(serviceUUIDs)
+				self.l.d("\(#function). operation ID: \(id)")
+				if let serviceUUIDs {
+					for sid in serviceUUIDs {
+						self.l.d("Services: \(sid)")
+					}
+				} else {
+					self.l.d("All services")
+				}
+			}
+			
+			self.peripheralDelegate.discoveredServicesQueue.addOperation(operation)
+		}
+		.autoconnect()
+		.eraseToAnyPublisher()
+	}
+	
+	/// Discovers the specified included services of a previously-discovered service.
+	public func discoverIncludedServices(_ includedServiceUUIDs: [CBUUID]?, for: CBService) -> AnyPublisher<[CBService], Error> {
+		fatalError()
+	}
+	
+	/// A list of a peripheral’s discovered services.
+	public var services: [CBService]? {
+		peripheral.services
+	}
 }
 
 //MARK: - Discovering Characteristics and Descriptorsin page link
 extension Peripheral {
 
 	/// Discover characteristics for a given service.
-    ///
-    /// - Parameters:
-    ///   - characteristicUUIDs: An optional array of characteristic UUIDs to filter the discovery results. If nil, all characteristics will be discovered.
-    ///   - service: The service for which to discover characteristics.
-    /// - Returns: A publisher emitting discovered characteristics or an error.
+	///
+	/// - Parameters:
+	///   - characteristicUUIDs: An optional array of characteristic UUIDs to filter the discovery results. If nil, all characteristics will be discovered.
+	///   - service: The service for which to discover characteristics.
+	/// - Returns: A publisher emitting discovered characteristics or an error.
 	public func discoverCharacteristics(
 		_ characteristicUUIDs: [CBUUID]?, for service: CBService
 	) -> AnyPublisher<[CBCharacteristic], Error> {
-        let id = UUID()
-        
+		let id = UUID()
+		
 		let allCharacteristics = peripheralDelegate.discoveredCharacteristicsSubject
-            .filter {
-                $0.value.0.uuid == service.uuid
-            }
-            .first(where: { $0.id == id } )
+			.filter {
+				$0.value.0.uuid == service.uuid
+			}
+			.first(where: { $0.id == id } )
 			.tryCompactMap { result throws -> [CBCharacteristic]? in
-                if let e = result.error {
+				if let e = result.error {
 					throw e
 				} else {
-                    return result.value.1
+					return result.value.1
 				}
 			}
-            .first()
+			.first()
 
 		return allCharacteristics.bluetooth {
-            self.peripheralDelegate.discoveredCharacteristicsQueue.enqueue(id)
+			self.peripheralDelegate.discoveredCharacteristicsQueue.enqueue(id)
 			self.peripheral.discoverCharacteristics(characteristicUUIDs, for: service)
 		}
-        .autoconnect()
-        .eraseToAnyPublisher()
+		.autoconnect()
+		.eraseToAnyPublisher()
 	}
 
 	/// Discover descriptors for a given characteristic.
-    ///
-    /// - Parameter characteristic: The characteristic for which to discover descriptors.
-    /// - Returns: A publisher emitting discovered descriptors or an error.
+	///
+	/// - Parameter characteristic: The characteristic for which to discover descriptors.
+	/// - Returns: A publisher emitting discovered descriptors or an error.
 	public func discoverDescriptors(for characteristic: CBCharacteristic)
 		-> AnyPublisher<[CBDescriptor], Error>
 	{
-        let id = UUID()
-        
+		let id = UUID()
+		
 		return peripheralDelegate.discoveredDescriptorsSubject
 			.filter {
-                $0.value.0.uuid == characteristic.uuid 
-                
+				$0.value.0.uuid == characteristic.uuid 
+				
 			}
-            .first(where: { $0.id == id })
+			.first(where: { $0.id == id })
 			.tryCompactMap { result throws -> [CBDescriptor]? in
-                if let e = result.error {
+				if let e = result.error {
 					throw e
 				} else {
-                    return result.value.1
+					return result.value.1
 				}
 			}
-            .first()
+			.first()
 			.bluetooth {
-                self.peripheralDelegate.discoveredDescriptorsQueue.enqueue(id)
+				self.peripheralDelegate.discoveredDescriptorsQueue.enqueue(id)
 				self.peripheral.discoverDescriptors(for: characteristic)
 			}
-            .autoconnect()
-            .eraseToAnyPublisher()
+			.autoconnect()
+			.eraseToAnyPublisher()
 	}
 }
 
 // MARK: - Reading Characteristic and Descriptor Values
 extension Peripheral {
-    /// Read the value of a characteristic.
-    ///
-    /// - Parameter characteristic: The characteristic to read from.
-    /// - Returns: A future emitting the read data or an error.
-    public func readValue(for characteristic: CBCharacteristic) -> Future<Data?, Error> {
-        return characteristicReader.readValue(from: characteristic)
-    }
+	/// Read the value of a characteristic.
+	///
+	/// - Parameter characteristic: The characteristic to read from.
+	/// - Returns: A future emitting the read data or an error.
+	public func readValue(for characteristic: CBCharacteristic) -> Future<Data?, Error> {
+		return characteristicReader.readValue(from: characteristic)
+	}
 
-    /// Listen for updates to the value of a characteristic.
-    ///
-    /// - Parameter characteristic: The characteristic to monitor for updates.
-    /// - Returns: A publisher emitting characteristic values or an error.
-    public func listenValues(for characteristic: CBCharacteristic) -> AnyPublisher<Data, Error>
-    {
-        return peripheralDelegate.updatedCharacteristicValuesSubject
-            .filter {
-                $0.0.uuid == characteristic.uuid &&
-                $0.0.service?.uuid == characteristic.service?.uuid
-            }
-            .tryCompactMap { (ch, err) in
-                if let err {
-                    throw err
-                }
+	/// Listen for updates to the value of a characteristic.
+	///
+	/// - Parameter characteristic: The characteristic to monitor for updates.
+	/// - Returns: A publisher emitting characteristic values or an error.
+	public func listenValues(for characteristic: CBCharacteristic) -> AnyPublisher<Data, Error>
+	{
+		return peripheralDelegate.updatedCharacteristicValuesSubject
+			.filter {
+				$0.0.uuid == characteristic.uuid &&
+				$0.0.service?.uuid == characteristic.service?.uuid
+			}
+			.tryCompactMap { (ch, err) in
+				if let err {
+					throw err
+				}
 
-                return ch.value
-            }
-            .eraseToAnyPublisher()
-    }
+				return ch.value
+			}
+			.eraseToAnyPublisher()
+	}
 
-    /// Read the value of a descriptor.
-    ///
-    /// - Parameter descriptor: The descriptor to read from.
-    /// - Returns: A future emitting the read data or an error.
-    public func readValue(for descriptor: CBDescriptor) -> Future<Any?, Error> {
-        return descriptorReader.readValue(from: descriptor)
-    }
+	/// Read the value of a descriptor.
+	///
+	/// - Parameter descriptor: The descriptor to read from.
+	/// - Returns: A future emitting the read data or an error.
+	public func readValue(for descriptor: CBDescriptor) -> Future<Any?, Error> {
+		return descriptorReader.readValue(from: descriptor)
+	}
 }
 
 // MARK: - Writing Characteristic and Descriptor Values
 extension Peripheral {
 	/// Write data to a characteristic and wait for a response.
-    ///
-    /// - Parameters:
-    ///   - data: The data to write.
-    ///   - characteristic: The characteristic to write to.
-    /// - Returns: A publisher indicating success or an error.
+	///
+	/// - Parameters:
+	///   - data: The data to write.
+	///   - characteristic: The characteristic to write to.
+	/// - Returns: A publisher indicating success or an error.
 	public func writeValueWithResponse(_ data: Data, for characteristic: CBCharacteristic)
 		-> AnyPublisher<Void, Error>
 	{
@@ -349,51 +349,51 @@ extension Peripheral {
 				self.peripheral.writeValue(
 					data, for: characteristic, type: .withResponse)
 			}
-            .autoconnect()
-            .eraseToAnyPublisher()
+			.autoconnect()
+			.eraseToAnyPublisher()
 	}
 
 	/// Write data to a characteristic without waiting for a response.
-    ///
-    /// - Parameters:
-    ///   - data: The data to write.
-    ///   - characteristic: The characteristic to write to.
+	///
+	/// - Parameters:
+	///   - data: The data to write.
+	///   - characteristic: The characteristic to write to.
 	public func writeValueWithoutResponse(_ data: Data, for characteristic: CBCharacteristic) {
 		peripheral.writeValue(data, for: characteristic, type: .withoutResponse)
 	}
 
 	/// Write data to a descriptor.
-    ///
-    /// - Parameters:
-    ///   - data: The data to write.
-    ///   - descriptor: The descriptor to write to.
+	///
+	/// - Parameters:
+	///   - data: The data to write.
+	///   - descriptor: The descriptor to write to.
 	public func writeValue(_ data: Data, for descriptor: CBDescriptor) -> Future<Void, Error> {
-        return descriptorWriter.write(data, to: descriptor)
+		return descriptorWriter.write(data, to: descriptor)
 	}
 }
 
 // MARK: - Setting Notifications for a Characteristic’s Value
 extension Peripheral {
 	/// Set notification state for a characteristic.
-    ///
-    /// - Parameters:
-    ///   - isEnabled: Whether notifications should be enabled or disabled.
-    ///   - characteristic: The characteristic for which to set the notification state.
-    /// - Returns: A publisher indicating success or an error.
+	///
+	/// - Parameters:
+	///   - isEnabled: Whether notifications should be enabled or disabled.
+	///   - characteristic: The characteristic for which to set the notification state.
+	/// - Returns: A publisher indicating success or an error.
 	public func setNotifyValue(_ isEnabled: Bool, for characteristic: CBCharacteristic)
 		-> AnyPublisher<Bool, Error>
 	{
 		if characteristic.isNotifying == isEnabled {
 			return Just(isEnabled)
 				.setFailureType(to: Error.self)
-                .eraseToAnyPublisher()
+				.eraseToAnyPublisher()
 		}
 
 		return peripheralDelegate.notificationStateSubject
 			.first {
-                $0.0.uuid == characteristic.uuid &&
-                $0.0.service?.uuid == characteristic.service?.uuid
-            }
+				$0.0.uuid == characteristic.uuid &&
+				$0.0.service?.uuid == characteristic.service?.uuid
+			}
 			.tryMap { result in
 				if let e = result.1 {
 					throw e
@@ -403,132 +403,132 @@ extension Peripheral {
 			.bluetooth {
 				self.peripheral.setNotifyValue(isEnabled, for: characteristic)
 			}
-            .autoconnect()
-            .eraseToAnyPublisher()
+			.autoconnect()
+			.eraseToAnyPublisher()
 	}
 }
 
 // MARK: - Accessing a Peripheral’s Signal Strengthin page link
 extension Peripheral {
-    /// Retrieves the current RSSI value for the peripheral while connected to the central manager.
-    public func readRSSI() -> AnyPublisher<NSNumber, Error> {
-        peripheralDelegate.readRSSISubject
-            .tryMap { rssi in
-                if let error = rssi.1 {
-                    throw error
-                } else {
-                    return rssi.0
-                }
-            }
-            .first()
-            .bluetooth {
-                self.peripheral.readRSSI()
-            }
-            .autoconnect()
-            .eraseToAnyPublisher()
-    }
+	/// Retrieves the current RSSI value for the peripheral while connected to the central manager.
+	public func readRSSI() -> AnyPublisher<NSNumber, Error> {
+		peripheralDelegate.readRSSISubject
+			.tryMap { rssi in
+				if let error = rssi.1 {
+					throw error
+				} else {
+					return rssi.0
+				}
+			}
+			.first()
+			.bluetooth {
+				self.peripheral.readRSSI()
+			}
+			.autoconnect()
+			.eraseToAnyPublisher()
+	}
 }
 
 // MARK: - Channels
 extension Peripheral {
-    /// A publisher that emits the discovered services of the peripheral.
-    public var discoveredServicesChannel: AnyPublisher<[CBService]?, Error> {
-        peripheralDelegate.discoveredServicesSubject
-            .tryMap { result in
-                if let e = result.error {
-                    throw e
-                } else {
-                    return result.value
-                }
-            }
-            .eraseToAnyPublisher()
-    }
+	/// A publisher that emits the discovered services of the peripheral.
+	public var discoveredServicesChannel: AnyPublisher<[CBService]?, Error> {
+		peripheralDelegate.discoveredServicesSubject
+			.tryMap { result in
+				if let e = result.error {
+					throw e
+				} else {
+					return result.value
+				}
+			}
+			.eraseToAnyPublisher()
+	}
 
-    /// A publisher that emits the discovered characteristics of a service.
-    public var discoveredCharacteristicsChannel: AnyPublisher<(CBService, [CBCharacteristic]?)?, Error> {
-        peripheralDelegate.discoveredCharacteristicsSubject
-            .tryMap { result in
-                if let e = result.error {
-                    throw e
-                } else {
-                    return result.value
-                }
-            }
-            .eraseToAnyPublisher()
-    }
+	/// A publisher that emits the discovered characteristics of a service.
+	public var discoveredCharacteristicsChannel: AnyPublisher<(CBService, [CBCharacteristic]?)?, Error> {
+		peripheralDelegate.discoveredCharacteristicsSubject
+			.tryMap { result in
+				if let e = result.error {
+					throw e
+				} else {
+					return result.value
+				}
+			}
+			.eraseToAnyPublisher()
+	}
 
-    /// A publisher that emits the discovered descriptors of a characteristic.
-    public var discoveredDescriptorsChannel: AnyPublisher<(CBCharacteristic, [CBDescriptor]?)?, Error> {
-        peripheralDelegate.discoveredDescriptorsSubject
-            .tryMap { result in
-                if let e = result.error {
-                    throw e
-                } else {
-                    return result.value
-                }
-            }
-            .eraseToAnyPublisher()
-    }
+	/// A publisher that emits the discovered descriptors of a characteristic.
+	public var discoveredDescriptorsChannel: AnyPublisher<(CBCharacteristic, [CBDescriptor]?)?, Error> {
+		peripheralDelegate.discoveredDescriptorsSubject
+			.tryMap { result in
+				if let e = result.error {
+					throw e
+				} else {
+					return result.value
+				}
+			}
+			.eraseToAnyPublisher()
+	}
 
-    /// A publisher that emits the updated value of a characteristic.
-    public var updatedCharacteristicValuesChannel: AnyPublisher<(CBCharacteristic, Error?), Never> {
-        peripheralDelegate.updatedCharacteristicValuesSubject
-            .eraseToAnyPublisher()
-    }
+	/// A publisher that emits the updated value of a characteristic.
+	public var updatedCharacteristicValuesChannel: AnyPublisher<(CBCharacteristic, Error?), Never> {
+		peripheralDelegate.updatedCharacteristicValuesSubject
+			.eraseToAnyPublisher()
+	}
 
-    /// A publisher that emits the updated value of a descriptor.
-    public var updatedDescriptorValuesChannel: AnyPublisher<(CBDescriptor, Error?), Never> {
-        peripheralDelegate.updatedDescriptorValuesSubject
-            .eraseToAnyPublisher()
-    }
+	/// A publisher that emits the updated value of a descriptor.
+	public var updatedDescriptorValuesChannel: AnyPublisher<(CBDescriptor, Error?), Never> {
+		peripheralDelegate.updatedDescriptorValuesSubject
+			.eraseToAnyPublisher()
+	}
 
-    /// A publisher that emits the written value of a characteristic.
-    public var writtenCharacteristicValuesChannel: AnyPublisher<(CBCharacteristic, Error?), Never> {
-        peripheralDelegate.writtenCharacteristicValuesSubject
-            .eraseToAnyPublisher()
-    }
+	/// A publisher that emits the written value of a characteristic.
+	public var writtenCharacteristicValuesChannel: AnyPublisher<(CBCharacteristic, Error?), Never> {
+		peripheralDelegate.writtenCharacteristicValuesSubject
+			.eraseToAnyPublisher()
+	}
 
-    /// A publisher that emits the written value of a descriptor.
-    public var writtenDescriptorValuesChannel: AnyPublisher<(CBDescriptor, Error?), Never> {
-        peripheralDelegate.writtenDescriptorValuesSubject
-            .eraseToAnyPublisher()
-    }
+	/// A publisher that emits the written value of a descriptor.
+	public var writtenDescriptorValuesChannel: AnyPublisher<(CBDescriptor, Error?), Never> {
+		peripheralDelegate.writtenDescriptorValuesSubject
+			.eraseToAnyPublisher()
+	}
 
-    /// A publisher that emits the notification state of a characteristic.
-    public var notificationStateChannel: AnyPublisher<(CBCharacteristic, Error?), Never> {
-        peripheralDelegate.notificationStateSubject
-            .eraseToAnyPublisher()
-    }
+	/// A publisher that emits the notification state of a characteristic.
+	public var notificationStateChannel: AnyPublisher<(CBCharacteristic, Error?), Never> {
+		peripheralDelegate.notificationStateSubject
+			.eraseToAnyPublisher()
+	}
 
-    /// A publisher that emits the update name of a peripheral.
-    public var updateNameChannel: AnyPublisher<String?, Never> {
-        peripheralDelegate.updateNameSubject
-            .eraseToAnyPublisher()
-    }
+	/// A publisher that emits the update name of a peripheral.
+	public var updateNameChannel: AnyPublisher<String?, Never> {
+		peripheralDelegate.updateNameSubject
+			.eraseToAnyPublisher()
+	}
 
-    public var modifyServices: AnyPublisher<[CBService], Never> {
-        peripheralDelegate.modifyServicesSubject
-            .eraseToAnyPublisher()
-    }
+	public var modifyServices: AnyPublisher<[CBService], Never> {
+		peripheralDelegate.modifyServicesSubject
+			.eraseToAnyPublisher()
+	}
 
-    /// A publisher that emits the read RSSI value of a peripheral.
-    public var readRSSIChannel: AnyPublisher<NSNumber?, Error> {
-        peripheralDelegate.readRSSISubject
-            .tryMap { rssi in
-                if let error = rssi.1 {
-                    throw error
-                } else {
-                    return rssi.0
-                }
-            }
-            .eraseToAnyPublisher()
-    }
+	/// A publisher that emits the read RSSI value of a peripheral.
+	public var readRSSIChannel: AnyPublisher<NSNumber?, Error> {
+		peripheralDelegate.readRSSISubject
+			.tryMap { rssi in
+				if let error = rssi.1 {
+					throw error
+				} else {
+					return rssi.0
+				}
+			}
+			.eraseToAnyPublisher()
+	}
 
-    /// A publisher that emits the isReadyToSendWriteWithoutResponse value of a peripheral.
-    public var isReadyToSendWriteWithoutResponseChannel: AnyPublisher<Void, Never> {
-        peripheralDelegate.isReadyToSendWriteWithoutResponseSubject
-            .first()
-            .eraseToAnyPublisher()
-    }
+	/// A publisher that emits the isReadyToSendWriteWithoutResponse value of a peripheral.
+	public var isReadyToSendWriteWithoutResponseChannel: AnyPublisher<Void, Never> {
+		peripheralDelegate.isReadyToSendWriteWithoutResponseSubject
+			.first()
+			.eraseToAnyPublisher()
+	}
 
 }

--- a/Sources/iOS-BLE-Library/Peripheral/Peripheral.swift
+++ b/Sources/iOS-BLE-Library/Peripheral/Peripheral.swift
@@ -327,7 +327,7 @@ extension Peripheral {
 		-> AnyPublisher<Void, Error>
 	{
 		return peripheralDelegate.writtenCharacteristicValuesSubject
-			.first(where: { $0.0.uuid == characteristic.uuid &&$0.0.service?.uuid == characteristic.service?.uuid })
+			.first(where: { $0.0.uuid == characteristic.uuid && $0.0.service?.uuid == characteristic.service?.uuid })
 			.tryMap { result in
 				if let e = result.1 {
 					throw e

--- a/Sources/iOS-BLE-Library/Peripheral/Peripheral.swift
+++ b/Sources/iOS-BLE-Library/Peripheral/Peripheral.swift
@@ -26,8 +26,8 @@ private class NativeObserver: Observer {
 
 	private weak var publisher: CurrentValueSubject<CBPeripheralState, Never>!
 	private var observation: NSKeyValueObservation?
-	
-	let l = L(category: "peripheral")
+    
+    let l = L(category: "peripheral")
 
 	init(
 		peripheral: CoreBluetooth.CBPeripheral,
@@ -41,9 +41,9 @@ private class NativeObserver: Observer {
 	override func setup() {
 		observation = peripheral.observe(\.state, options: [.new]) {
 			[weak self] _, change in
-			// TODO: Check threads
-			guard let self else { return }
-			self.publisher.send(self.peripheral.state)
+            // TODO: Check threads
+            guard let self else { return }
+            self.publisher.send(self.peripheral.state)
 		}
 	}
 }
@@ -53,36 +53,36 @@ private class NativeObserver: Observer {
 //CG_WITH
 /*
  private class MockObserver: Observer {
-	 @objc private var peripheral: CBMPeripheralMock
+     @objc private var peripheral: CBMPeripheralMock
 
-	 private weak var publisher: CurrentValueSubject<CBPeripheralState, Never>!
-	 private var observation: NSKeyValueObservation?
+     private weak var publisher: CurrentValueSubject<CBPeripheralState, Never>!
+     private var observation: NSKeyValueObservation?
 
-	 init(peripheral: CBMPeripheralMock, publisher: CurrentValueSubject<CBPeripheralState, Never>) {
-		 self.peripheral = peripheral
-		 self.publisher = publisher
-		 super.init()
-	 }
+     init(peripheral: CBMPeripheralMock, publisher: CurrentValueSubject<CBPeripheralState, Never>) {
+         self.peripheral = peripheral
+         self.publisher = publisher
+         super.init()
+     }
 
-	 override func setup() {
-		 observation = peripheral.observe(\.state, options: [.new]) { [weak self] _, change in
-			 #warning("queue can be not only main")
-			 DispatchQueue.main.async {
-				 guard let self else { return }
-				 self.publisher.send(self.peripheral.state)
-			 }
-		 }
-	 }
+     override func setup() {
+         observation = peripheral.observe(\.state, options: [.new]) { [weak self] _, change in
+             #warning("queue can be not only main")
+             DispatchQueue.main.async {
+                 guard let self else { return }
+                 self.publisher.send(self.peripheral.state)
+             }
+         }
+     }
  }
 */
 //CG_END
 
 
 public class Peripheral {
-	private var serviceDiscoveryQueue = Queue<UUID>()
-	
-	let l = L(category: #file)
-	
+    private var serviceDiscoveryQueue = Queue<UUID>()
+    
+    let l = L(category: #file)
+    
 	/// I'm Errr from Omicron Persei 8
 	public enum Err: Error {
 		case badDelegate
@@ -91,10 +91,10 @@ public class Peripheral {
 	/// The underlying CBPeripheral instance.
 	public let peripheral: CBPeripheral
 
-	// MARK: Identifying a Peripheralin page link
-	/// The name of the peripheral.
-	public var name: String? { peripheral.name }
-	
+    // MARK: Identifying a Peripheralin page link
+    /// The name of the peripheral.
+    public var name: String? { peripheral.name }
+    
 	/// The delegate for handling peripheral events.
 	public let peripheralDelegate: ReactivePeripheralDelegate
 
@@ -111,27 +111,27 @@ public class Peripheral {
 			.eraseToAnyPublisher(),
 		peripheral: peripheral
 	)
-	
-	private lazy var descriptorWriter = DescriptorWriter(
-		writtenEventsPublisher: self.peripheralDelegate.writtenDescriptorValuesSubject.eraseToAnyPublisher(),
-		peripheral: peripheral
-	)
-	
-	private lazy var descriptorReader = DescriptorReader(
-		updateEventsPublisher: self.peripheralDelegate.updatedDescriptorValuesSubject.eraseToAnyPublisher(),
-		peripheral: peripheral
-	)
+    
+    private lazy var descriptorWriter = DescriptorWriter(
+        writtenEventsPublisher: self.peripheralDelegate.writtenDescriptorValuesSubject.eraseToAnyPublisher(),
+        peripheral: peripheral
+    )
+    
+    private lazy var descriptorReader = DescriptorReader(
+        updateEventsPublisher: self.peripheralDelegate.updatedDescriptorValuesSubject.eraseToAnyPublisher(),
+        peripheral: peripheral
+    )
 
 	// TODO: Why don't we use default delegate?
 	/// Initializes a Peripheral instance.
-	///
-	/// - Parameters:
-	///   - peripheral: The CBPeripheral to manage.
-	///   - delegate: The delegate for handling peripheral events.
+    ///
+    /// - Parameters:
+    ///   - peripheral: The CBPeripheral to manage.
+    ///   - delegate: The delegate for handling peripheral events.
 	public init(peripheral: CBPeripheral, delegate: ReactivePeripheralDelegate = ReactivePeripheralDelegate()) {
 		self.peripheral = peripheral
 		self.peripheralDelegate = delegate
-		assert(peripheral.delegate == nil, "CBPeripheral's delegate should be nil, otherwise it can lead to problems")
+        assert(peripheral.delegate == nil, "CBPeripheral's delegate should be nil, otherwise it can lead to problems")
 		peripheral.delegate = delegate
 
 //CG_REPLACE
@@ -139,13 +139,13 @@ public class Peripheral {
 		observer.setup()
 //CG_WITH
 /*
-		 if let p = peripheral as? CBMPeripheralNative {
-					 observer = NativeObserver(peripheral: p.peripheral, publisher: stateSubject)
-					 observer.setup()
-				 } else if let p = peripheral as? CBMPeripheralMock {
-					 observer = MockObserver(peripheral: p, publisher: stateSubject)
-					 observer.setup()
-				 }
+         if let p = peripheral as? CBMPeripheralNative {
+                     observer = NativeObserver(peripheral: p.peripheral, publisher: stateSubject)
+                     observer.setup()
+                 } else if let p = peripheral as? CBMPeripheralMock {
+                     observer = MockObserver(peripheral: p, publisher: stateSubject)
+                     observer.setup()
+                 }
 */
 //CG_END
 	}
@@ -161,183 +161,173 @@ extension Peripheral {
 
 // MARK: - Discovering Servicesin page link
 extension Peripheral {
-	/// Discover services for the peripheral.
-	///
-	/// - Parameter serviceUUIDs: An optional array of service UUIDs to filter the discovery results. If nil, all services will be discovered.
-	/// - Returns: A publisher emitting discovered services or an error.
-	public func discoverServices(serviceUUIDs: [CBUUID]?)
-	-> AnyPublisher<[CBService], Error>
-	{
-		let id = UUID()
-		
-		let allServices = peripheralDelegate.discoveredServicesSubject
-			.first(where: { $0.id == id } )
-			.tryCompactMap { result throws -> [CBService]? in
-				if let e = result.error {
-					throw e
-				} else {
-					return result.value
-				}
-			}
-			.first()
-		
-		return allServices.bluetooth {
-			let operation = IdentifiableOperation(id: id) {
-				self.peripheral.discoverServices(serviceUUIDs)
-				self.l.d("\(#function). operation ID: \(id)")
-				if let serviceUUIDs {
-					for sid in serviceUUIDs {
-						self.l.d("Services: \(sid)")
-					}
-				} else {
-					self.l.d("All services")
-				}
-			}
-			
-			self.peripheralDelegate.discoveredServicesQueue.addOperation(operation)
-		}
-		.autoconnect()
-		.eraseToAnyPublisher()
-	}
-	
-	/// Discovers the specified included services of a previously-discovered service.
-	public func discoverIncludedServices(_ includedServiceUUIDs: [CBUUID]?, for: CBService) -> AnyPublisher<[CBService], Error> {
-		fatalError()
-	}
-	
-	/// A list of a peripheral’s discovered services.
-	public var services: [CBService]? {
-		peripheral.services
-	}
+    /// Discover services for the peripheral.
+    ///
+    /// - Parameter serviceUUIDs: An optional array of service UUIDs to filter the discovery results. If nil, all services will be discovered.
+    /// - Returns: A publisher emitting discovered services or an error.
+    public func discoverServices(serviceUUIDs: [CBUUID]?)
+    -> AnyPublisher<[CBService], Error>
+    {
+        let id = UUID()
+        
+        let allServices = peripheralDelegate.discoveredServicesSubject
+            .first(where: { $0.id == id } )
+            .tryCompactMap { result throws -> [CBService]? in
+                if let e = result.error {
+                    throw e
+                } else {
+                    return result.value
+                }
+            }
+            .first()
+        
+        return allServices.bluetooth {
+            let operation = IdentifiableOperation(id: id) {
+                self.peripheral.discoverServices(serviceUUIDs)
+                self.l.d("\(#function). operation ID: \(id)")
+                if let serviceUUIDs {
+                    for sid in serviceUUIDs {
+                        self.l.d("Services: \(sid)")
+                    }
+                } else {
+                    self.l.d("All services")
+                }
+            }
+            
+            self.peripheralDelegate.discoveredServicesQueue.addOperation(operation)
+        }
+        .autoconnect()
+        .eraseToAnyPublisher()
+    }
+    
+    /// Discovers the specified included services of a previously-discovered service.
+    public func discoverIncludedServices(_ includedServiceUUIDs: [CBUUID]?, for: CBService) -> AnyPublisher<[CBService], Error> {
+        fatalError()
+    }
+    
+    /// A list of a peripheral’s discovered services.
+    public var services: [CBService]? {
+        peripheral.services
+    }
 }
 
 //MARK: - Discovering Characteristics and Descriptorsin page link
 extension Peripheral {
 
 	/// Discover characteristics for a given service.
-	///
-	/// - Parameters:
-	///   - characteristicUUIDs: An optional array of characteristic UUIDs to filter the discovery results. If nil, all characteristics will be discovered.
-	///   - service: The service for which to discover characteristics.
-	/// - Returns: A publisher emitting discovered characteristics or an error.
+    ///
+    /// - Parameters:
+    ///   - characteristicUUIDs: An optional array of characteristic UUIDs to filter the discovery results. If nil, all characteristics will be discovered.
+    ///   - service: The service for which to discover characteristics.
+    /// - Returns: A publisher emitting discovered characteristics or an error.
 	public func discoverCharacteristics(
 		_ characteristicUUIDs: [CBUUID]?, for service: CBService
 	) -> AnyPublisher<[CBCharacteristic], Error> {
-		let id = UUID()
-		
+        let id = UUID()
+        
 		let allCharacteristics = peripheralDelegate.discoveredCharacteristicsSubject
-			.filter {
-				$0.value.0.uuid == service.uuid
-			}
-			.first(where: { $0.id == id } )
+            .filter {
+                $0.value.0.uuid == service.uuid
+            }
+            .first(where: { $0.id == id } )
 			.tryCompactMap { result throws -> [CBCharacteristic]? in
-				if let e = result.error {
+                if let e = result.error {
 					throw e
 				} else {
-					return result.value.1
+                    return result.value.1
 				}
 			}
-			.first()
+            .first()
 
 		return allCharacteristics.bluetooth {
-			self.peripheralDelegate.discoveredCharacteristicsQueue.enqueue(id)
+            self.peripheralDelegate.discoveredCharacteristicsQueue.enqueue(id)
 			self.peripheral.discoverCharacteristics(characteristicUUIDs, for: service)
 		}
-		.autoconnect()
-		.eraseToAnyPublisher()
+        .autoconnect()
+        .eraseToAnyPublisher()
 	}
 
 	/// Discover descriptors for a given characteristic.
-	///
-	/// - Parameter characteristic: The characteristic for which to discover descriptors.
-	/// - Returns: A publisher emitting discovered descriptors or an error.
+    ///
+    /// - Parameter characteristic: The characteristic for which to discover descriptors.
+    /// - Returns: A publisher emitting discovered descriptors or an error.
 	public func discoverDescriptors(for characteristic: CBCharacteristic)
 		-> AnyPublisher<[CBDescriptor], Error>
 	{
-		let id = UUID()
-		
+        let id = UUID()
+        
 		return peripheralDelegate.discoveredDescriptorsSubject
 			.filter {
-				$0.value.0.uuid == characteristic.uuid 
-				
+                $0.value.0.uuid == characteristic.uuid
 			}
-			.first(where: { $0.id == id })
+            .first(where: { $0.id == id })
 			.tryCompactMap { result throws -> [CBDescriptor]? in
-				if let e = result.error {
+                if let e = result.error {
 					throw e
 				} else {
-					return result.value.1
+                    return result.value.1
 				}
 			}
-			.first()
+            .first()
 			.bluetooth {
-				self.peripheralDelegate.discoveredDescriptorsQueue.enqueue(id)
+                self.peripheralDelegate.discoveredDescriptorsQueue.enqueue(id)
 				self.peripheral.discoverDescriptors(for: characteristic)
 			}
-			.autoconnect()
-			.eraseToAnyPublisher()
+            .autoconnect()
+            .eraseToAnyPublisher()
 	}
 }
 
 // MARK: - Reading Characteristic and Descriptor Values
 extension Peripheral {
-	/// Read the value of a characteristic.
-	///
-	/// - Parameter characteristic: The characteristic to read from.
-	/// - Returns: A future emitting the read data or an error.
-	public func readValue(for characteristic: CBCharacteristic) -> Future<Data?, Error> {
-		return characteristicReader.readValue(from: characteristic)
-	}
+    /// Read the value of a characteristic.
+    ///
+    /// - Parameter characteristic: The characteristic to read from.
+    /// - Returns: A future emitting the read data or an error.
+    public func readValue(for characteristic: CBCharacteristic) -> Future<Data?, Error> {
+        return characteristicReader.readValue(from: characteristic)
+    }
 
-	/// Listen for updates to the value of a characteristic.
-	///
-	/// - Parameter characteristic: The characteristic to monitor for updates.
-	/// - Returns: A publisher emitting characteristic values or an error.
-	public func listenValues(for characteristic: CBCharacteristic) -> AnyPublisher<Data, Error>
-	{
-		return peripheralDelegate.updatedCharacteristicValuesSubject
-			.filter {
-				$0.0.uuid == characteristic.uuid &&
-				$0.0.service?.uuid == characteristic.service?.uuid
-			}
-			.tryCompactMap { (ch, err) in
-				if let err {
-					throw err
-				}
+    /// Listen for updates to the value of a characteristic.
+    ///
+    /// - Parameter characteristic: The characteristic to monitor for updates.
+    /// - Returns: A publisher emitting characteristic values or an error.
+    public func listenValues(for characteristic: CBCharacteristic) -> AnyPublisher<Data, Error>
+    {
+        return peripheralDelegate.updatedCharacteristicValuesSubject
+            .filter { $0.0.uuid == characteristic.uuid && $0.0.service?.uuid == characteristic.service?.uuid }
+            .tryCompactMap { (ch, err) in
+                if let err {
+                    throw err
+                }
 
-				return ch.value
-			}
-			.eraseToAnyPublisher()
-	}
+                return ch.value
+            }
+            .eraseToAnyPublisher()
+    }
 
-	/// Read the value of a descriptor.
-	///
-	/// - Parameter descriptor: The descriptor to read from.
-	/// - Returns: A future emitting the read data or an error.
-	public func readValue(for descriptor: CBDescriptor) -> Future<Any?, Error> {
-		return descriptorReader.readValue(from: descriptor)
-	}
+    /// Read the value of a descriptor.
+    ///
+    /// - Parameter descriptor: The descriptor to read from.
+    /// - Returns: A future emitting the read data or an error.
+    public func readValue(for descriptor: CBDescriptor) -> Future<Any?, Error> {
+        return descriptorReader.readValue(from: descriptor)
+    }
 }
 
 // MARK: - Writing Characteristic and Descriptor Values
 extension Peripheral {
 	/// Write data to a characteristic and wait for a response.
-	///
-	/// - Parameters:
-	///   - data: The data to write.
-	///   - characteristic: The characteristic to write to.
-	/// - Returns: A publisher indicating success or an error.
+    ///
+    /// - Parameters:
+    ///   - data: The data to write.
+    ///   - characteristic: The characteristic to write to.
+    /// - Returns: A publisher indicating success or an error.
 	public func writeValueWithResponse(_ data: Data, for characteristic: CBCharacteristic)
 		-> AnyPublisher<Void, Error>
 	{
 		return peripheralDelegate.writtenCharacteristicValuesSubject
-			.map{ result in
-				return result
-			}
-			.first(where: {
-				$0.0.uuid == characteristic.uuid &&
-				$0.0.service?.uuid == characteristic.service?.uuid
-			})
+			.first(where: { $0.0.uuid == characteristic.uuid &&$0.0.service?.uuid == characteristic.service?.uuid })
 			.tryMap { result in
 				if let e = result.1 {
 					throw e
@@ -349,51 +339,48 @@ extension Peripheral {
 				self.peripheral.writeValue(
 					data, for: characteristic, type: .withResponse)
 			}
-			.autoconnect()
-			.eraseToAnyPublisher()
+            .autoconnect()
+            .eraseToAnyPublisher()
 	}
 
 	/// Write data to a characteristic without waiting for a response.
-	///
-	/// - Parameters:
-	///   - data: The data to write.
-	///   - characteristic: The characteristic to write to.
+    ///
+    /// - Parameters:
+    ///   - data: The data to write.
+    ///   - characteristic: The characteristic to write to.
 	public func writeValueWithoutResponse(_ data: Data, for characteristic: CBCharacteristic) {
 		peripheral.writeValue(data, for: characteristic, type: .withoutResponse)
 	}
 
 	/// Write data to a descriptor.
-	///
-	/// - Parameters:
-	///   - data: The data to write.
-	///   - descriptor: The descriptor to write to.
+    ///
+    /// - Parameters:
+    ///   - data: The data to write.
+    ///   - descriptor: The descriptor to write to.
 	public func writeValue(_ data: Data, for descriptor: CBDescriptor) -> Future<Void, Error> {
-		return descriptorWriter.write(data, to: descriptor)
+        return descriptorWriter.write(data, to: descriptor)
 	}
 }
 
 // MARK: - Setting Notifications for a Characteristic’s Value
 extension Peripheral {
 	/// Set notification state for a characteristic.
-	///
-	/// - Parameters:
-	///   - isEnabled: Whether notifications should be enabled or disabled.
-	///   - characteristic: The characteristic for which to set the notification state.
-	/// - Returns: A publisher indicating success or an error.
+    ///
+    /// - Parameters:
+    ///   - isEnabled: Whether notifications should be enabled or disabled.
+    ///   - characteristic: The characteristic for which to set the notification state.
+    /// - Returns: A publisher indicating success or an error.
 	public func setNotifyValue(_ isEnabled: Bool, for characteristic: CBCharacteristic)
 		-> AnyPublisher<Bool, Error>
 	{
 		if characteristic.isNotifying == isEnabled {
 			return Just(isEnabled)
 				.setFailureType(to: Error.self)
-				.eraseToAnyPublisher()
+                .eraseToAnyPublisher()
 		}
 
 		return peripheralDelegate.notificationStateSubject
-			.first {
-				$0.0.uuid == characteristic.uuid &&
-				$0.0.service?.uuid == characteristic.service?.uuid
-			}
+			.first { $0.0.uuid == characteristic.uuid && $0.0.service?.uuid == characteristic.service?.uuid }
 			.tryMap { result in
 				if let e = result.1 {
 					throw e
@@ -403,132 +390,132 @@ extension Peripheral {
 			.bluetooth {
 				self.peripheral.setNotifyValue(isEnabled, for: characteristic)
 			}
-			.autoconnect()
-			.eraseToAnyPublisher()
+            .autoconnect()
+            .eraseToAnyPublisher()
 	}
 }
 
 // MARK: - Accessing a Peripheral’s Signal Strengthin page link
 extension Peripheral {
-	/// Retrieves the current RSSI value for the peripheral while connected to the central manager.
-	public func readRSSI() -> AnyPublisher<NSNumber, Error> {
-		peripheralDelegate.readRSSISubject
-			.tryMap { rssi in
-				if let error = rssi.1 {
-					throw error
-				} else {
-					return rssi.0
-				}
-			}
-			.first()
-			.bluetooth {
-				self.peripheral.readRSSI()
-			}
-			.autoconnect()
-			.eraseToAnyPublisher()
-	}
+    /// Retrieves the current RSSI value for the peripheral while connected to the central manager.
+    public func readRSSI() -> AnyPublisher<NSNumber, Error> {
+        peripheralDelegate.readRSSISubject
+            .tryMap { rssi in
+                if let error = rssi.1 {
+                    throw error
+                } else {
+                    return rssi.0
+                }
+            }
+            .first()
+            .bluetooth {
+                self.peripheral.readRSSI()
+            }
+            .autoconnect()
+            .eraseToAnyPublisher()
+    }
 }
 
 // MARK: - Channels
 extension Peripheral {
-	/// A publisher that emits the discovered services of the peripheral.
-	public var discoveredServicesChannel: AnyPublisher<[CBService]?, Error> {
-		peripheralDelegate.discoveredServicesSubject
-			.tryMap { result in
-				if let e = result.error {
-					throw e
-				} else {
-					return result.value
-				}
-			}
-			.eraseToAnyPublisher()
-	}
+    /// A publisher that emits the discovered services of the peripheral.
+    public var discoveredServicesChannel: AnyPublisher<[CBService]?, Error> {
+        peripheralDelegate.discoveredServicesSubject
+            .tryMap { result in
+                if let e = result.error {
+                    throw e
+                } else {
+                    return result.value
+                }
+            }
+            .eraseToAnyPublisher()
+    }
 
-	/// A publisher that emits the discovered characteristics of a service.
-	public var discoveredCharacteristicsChannel: AnyPublisher<(CBService, [CBCharacteristic]?)?, Error> {
-		peripheralDelegate.discoveredCharacteristicsSubject
-			.tryMap { result in
-				if let e = result.error {
-					throw e
-				} else {
-					return result.value
-				}
-			}
-			.eraseToAnyPublisher()
-	}
+    /// A publisher that emits the discovered characteristics of a service.
+    public var discoveredCharacteristicsChannel: AnyPublisher<(CBService, [CBCharacteristic]?)?, Error> {
+        peripheralDelegate.discoveredCharacteristicsSubject
+            .tryMap { result in
+                if let e = result.error {
+                    throw e
+                } else {
+                    return result.value
+                }
+            }
+            .eraseToAnyPublisher()
+    }
 
-	/// A publisher that emits the discovered descriptors of a characteristic.
-	public var discoveredDescriptorsChannel: AnyPublisher<(CBCharacteristic, [CBDescriptor]?)?, Error> {
-		peripheralDelegate.discoveredDescriptorsSubject
-			.tryMap { result in
-				if let e = result.error {
-					throw e
-				} else {
-					return result.value
-				}
-			}
-			.eraseToAnyPublisher()
-	}
+    /// A publisher that emits the discovered descriptors of a characteristic.
+    public var discoveredDescriptorsChannel: AnyPublisher<(CBCharacteristic, [CBDescriptor]?)?, Error> {
+        peripheralDelegate.discoveredDescriptorsSubject
+            .tryMap { result in
+                if let e = result.error {
+                    throw e
+                } else {
+                    return result.value
+                }
+            }
+            .eraseToAnyPublisher()
+    }
 
-	/// A publisher that emits the updated value of a characteristic.
-	public var updatedCharacteristicValuesChannel: AnyPublisher<(CBCharacteristic, Error?), Never> {
-		peripheralDelegate.updatedCharacteristicValuesSubject
-			.eraseToAnyPublisher()
-	}
+    /// A publisher that emits the updated value of a characteristic.
+    public var updatedCharacteristicValuesChannel: AnyPublisher<(CBCharacteristic, Error?), Never> {
+        peripheralDelegate.updatedCharacteristicValuesSubject
+            .eraseToAnyPublisher()
+    }
 
-	/// A publisher that emits the updated value of a descriptor.
-	public var updatedDescriptorValuesChannel: AnyPublisher<(CBDescriptor, Error?), Never> {
-		peripheralDelegate.updatedDescriptorValuesSubject
-			.eraseToAnyPublisher()
-	}
+    /// A publisher that emits the updated value of a descriptor.
+    public var updatedDescriptorValuesChannel: AnyPublisher<(CBDescriptor, Error?), Never> {
+        peripheralDelegate.updatedDescriptorValuesSubject
+            .eraseToAnyPublisher()
+    }
 
-	/// A publisher that emits the written value of a characteristic.
-	public var writtenCharacteristicValuesChannel: AnyPublisher<(CBCharacteristic, Error?), Never> {
-		peripheralDelegate.writtenCharacteristicValuesSubject
-			.eraseToAnyPublisher()
-	}
+    /// A publisher that emits the written value of a characteristic.
+    public var writtenCharacteristicValuesChannel: AnyPublisher<(CBCharacteristic, Error?), Never> {
+        peripheralDelegate.writtenCharacteristicValuesSubject
+            .eraseToAnyPublisher()
+    }
 
-	/// A publisher that emits the written value of a descriptor.
-	public var writtenDescriptorValuesChannel: AnyPublisher<(CBDescriptor, Error?), Never> {
-		peripheralDelegate.writtenDescriptorValuesSubject
-			.eraseToAnyPublisher()
-	}
+    /// A publisher that emits the written value of a descriptor.
+    public var writtenDescriptorValuesChannel: AnyPublisher<(CBDescriptor, Error?), Never> {
+        peripheralDelegate.writtenDescriptorValuesSubject
+            .eraseToAnyPublisher()
+    }
 
-	/// A publisher that emits the notification state of a characteristic.
-	public var notificationStateChannel: AnyPublisher<(CBCharacteristic, Error?), Never> {
-		peripheralDelegate.notificationStateSubject
-			.eraseToAnyPublisher()
-	}
+    /// A publisher that emits the notification state of a characteristic.
+    public var notificationStateChannel: AnyPublisher<(CBCharacteristic, Error?), Never> {
+        peripheralDelegate.notificationStateSubject
+            .eraseToAnyPublisher()
+    }
 
-	/// A publisher that emits the update name of a peripheral.
-	public var updateNameChannel: AnyPublisher<String?, Never> {
-		peripheralDelegate.updateNameSubject
-			.eraseToAnyPublisher()
-	}
+    /// A publisher that emits the update name of a peripheral.
+    public var updateNameChannel: AnyPublisher<String?, Never> {
+        peripheralDelegate.updateNameSubject
+            .eraseToAnyPublisher()
+    }
 
-	public var modifyServices: AnyPublisher<[CBService], Never> {
-		peripheralDelegate.modifyServicesSubject
-			.eraseToAnyPublisher()
-	}
+    public var modifyServices: AnyPublisher<[CBService], Never> {
+        peripheralDelegate.modifyServicesSubject
+            .eraseToAnyPublisher()
+    }
 
-	/// A publisher that emits the read RSSI value of a peripheral.
-	public var readRSSIChannel: AnyPublisher<NSNumber?, Error> {
-		peripheralDelegate.readRSSISubject
-			.tryMap { rssi in
-				if let error = rssi.1 {
-					throw error
-				} else {
-					return rssi.0
-				}
-			}
-			.eraseToAnyPublisher()
-	}
+    /// A publisher that emits the read RSSI value of a peripheral.
+    public var readRSSIChannel: AnyPublisher<NSNumber?, Error> {
+        peripheralDelegate.readRSSISubject
+            .tryMap { rssi in
+                if let error = rssi.1 {
+                    throw error
+                } else {
+                    return rssi.0
+                }
+            }
+            .eraseToAnyPublisher()
+    }
 
-	/// A publisher that emits the isReadyToSendWriteWithoutResponse value of a peripheral.
-	public var isReadyToSendWriteWithoutResponseChannel: AnyPublisher<Void, Never> {
-		peripheralDelegate.isReadyToSendWriteWithoutResponseSubject
-			.first()
-			.eraseToAnyPublisher()
-	}
+    /// A publisher that emits the isReadyToSendWriteWithoutResponse value of a peripheral.
+    public var isReadyToSendWriteWithoutResponseChannel: AnyPublisher<Void, Never> {
+        peripheralDelegate.isReadyToSendWriteWithoutResponseSubject
+            .first()
+            .eraseToAnyPublisher()
+    }
 
 }

--- a/Sources/iOS-BLE-Library/Peripheral/Peripheral.swift
+++ b/Sources/iOS-BLE-Library/Peripheral/Peripheral.swift
@@ -258,7 +258,8 @@ extension Peripheral {
         
 		return peripheralDelegate.discoveredDescriptorsSubject
 			.filter {
-                $0.value.0.uuid == characteristic.uuid
+                $0.value.0.uuid == characteristic.uuid 
+                
 			}
             .first(where: { $0.id == id })
 			.tryCompactMap { result throws -> [CBDescriptor]? in
@@ -295,7 +296,10 @@ extension Peripheral {
     public func listenValues(for characteristic: CBCharacteristic) -> AnyPublisher<Data, Error>
     {
         return peripheralDelegate.updatedCharacteristicValuesSubject
-            .filter { $0.0.uuid == characteristic.uuid }
+            .filter {
+                $0.0.uuid == characteristic.uuid &&
+                $0.0.service?.uuid == characteristic.service?.uuid
+            }
             .tryCompactMap { (ch, err) in
                 if let err {
                     throw err
@@ -326,8 +330,16 @@ extension Peripheral {
 	public func writeValueWithResponse(_ data: Data, for characteristic: CBCharacteristic)
 		-> AnyPublisher<Void, Error>
 	{
+        print("......")
 		return peripheralDelegate.writtenCharacteristicValuesSubject
-			.first(where: { $0.0.uuid == characteristic.uuid })
+            .map{ result in
+                print("receive ...")
+                return result
+            }
+            .first(where: {
+                $0.0.uuid == characteristic.uuid &&
+                $0.0.service?.uuid == characteristic.service?.uuid
+            })
 			.tryMap { result in
 				if let e = result.1 {
 					throw e
@@ -380,7 +392,10 @@ extension Peripheral {
 		}
 
 		return peripheralDelegate.notificationStateSubject
-			.first { $0.0.uuid == characteristic.uuid }
+			.first {
+                $0.0.uuid == characteristic.uuid &&
+                $0.0.service?.uuid == characteristic.service?.uuid
+            }
 			.tryMap { result in
 				if let e = result.1 {
 					throw e


### PR DESCRIPTION
In the initial logic, only the UUID of a Bluetooth characteristic was used to link an action to its response. This led to issues when, for example, two characteristics with the same UUID existed in different services. For instance, a temperature sensor in the CPU service and another temperature sensor in a different service would share the same temperature reporting functionality. It’s logical that they would have the same UUID, but this setup could cause conflicts.