### PR TITLE
Unchecked Sendable Warnings

### DIFF
--- a/Sources/iOS-BLE-Library-Mock/Peripheral/Peripheral+Writer.swift
+++ b/Sources/iOS-BLE-Library-Mock/Peripheral/Peripheral+Writer.swift
@@ -126,7 +126,7 @@ extension Peripheral.DescriptorReader {
 	}
 }
 
-private class BasicOperation<T>: Operation {
+private class BasicOperation<T>: Operation, @unchecked Sendable {
 	let peripheral: CBPeripheral
 	var cancelable: AnyCancellable?
 
@@ -176,7 +176,7 @@ private class BasicOperation<T>: Operation {
 	}
 }
 
-private class WriteCharacteristicOperation: BasicOperation<Void> {
+private class WriteCharacteristicOperation: BasicOperation<Void>, @unchecked Sendable {
 
 	let writtenEventsPublisher: AnyPublisher<(CBCharacteristic, Error?), Never>
 	let characteristic: CBCharacteristic
@@ -230,7 +230,7 @@ private class WriteCharacteristicOperation: BasicOperation<Void> {
 	}
 }
 
-private class ReadCharacteristicOperation: BasicOperation<Data?> {
+private class ReadCharacteristicOperation: BasicOperation<Data?>, @unchecked Sendable {
 	let updateEventPublisher: AnyPublisher<(CBCharacteristic, Error?), Never>
 	let characteristic: CBCharacteristic
 
@@ -277,7 +277,7 @@ private class ReadCharacteristicOperation: BasicOperation<Data?> {
 	}
 }
 
-private class WriteDescriptorOperation: BasicOperation<Void> {
+private class WriteDescriptorOperation: BasicOperation<Void>, @unchecked Sendable {
 
 	let writtenEventsPublisher: AnyPublisher<(CBDescriptor, Error?), Never>
 	let descriptor: CBDescriptor
@@ -335,7 +335,7 @@ private class WriteDescriptorOperation: BasicOperation<Void> {
 	}
 }
 
-private class ReadDescriptorOperation: BasicOperation<Any?> {
+private class ReadDescriptorOperation: BasicOperation<Any?>, @unchecked Sendable {
 	let updateEventPublisher: AnyPublisher<(CBDescriptor, Error?), Never>
 	let descriptor: CBDescriptor
 

--- a/Sources/iOS-BLE-Library-Mock/Utilities/CBManagerState.swift
+++ b/Sources/iOS-BLE-Library-Mock/Utilities/CBManagerState.swift
@@ -12,7 +12,7 @@ import Foundation
 
 @available(iOS 10.0, *)
 @available(macOS 10.13, *)
-extension CBManagerState: CustomDebugStringConvertible, CustomStringConvertible {
+extension CBManagerState: @retroactive CustomDebugStringConvertible, @retroactive CustomStringConvertible {
 
 	public var debugDescription: String {
 		return description

--- a/Sources/iOS-BLE-Library/Peripheral/Peripheral+Writer.swift
+++ b/Sources/iOS-BLE-Library/Peripheral/Peripheral+Writer.swift
@@ -132,7 +132,7 @@ extension Peripheral.DescriptorReader {
     }
 }
 
-private class BasicOperation<T>: Operation {
+private class BasicOperation<T>: Operation, @unchecked Sendable {
 	let peripheral: CBPeripheral
 	var cancelable: AnyCancellable?
 
@@ -182,7 +182,7 @@ private class BasicOperation<T>: Operation {
 	}
 }
 
-private class WriteCharacteristicOperation: BasicOperation<Void> {
+private class WriteCharacteristicOperation: BasicOperation<Void>, @unchecked Sendable {
 
 	let writtenEventsPublisher: AnyPublisher<(CBCharacteristic, Error?), Never>
 	let characteristic: CBCharacteristic
@@ -236,7 +236,7 @@ private class WriteCharacteristicOperation: BasicOperation<Void> {
 	}
 }
 
-private class ReadCharacteristicOperation: BasicOperation<Data?> {
+private class ReadCharacteristicOperation: BasicOperation<Data?>, @unchecked Sendable {
 	let updateEventPublisher: AnyPublisher<(CBCharacteristic, Error?), Never>
 	let characteristic: CBCharacteristic
 
@@ -283,7 +283,7 @@ private class ReadCharacteristicOperation: BasicOperation<Data?> {
 	}
 }
 
-private class WriteDescriptorOperation: BasicOperation<Void> {
+private class WriteDescriptorOperation: BasicOperation<Void>, @unchecked Sendable {
 
     let writtenEventsPublisher: AnyPublisher<(CBDescriptor, Error?), Never>
     let descriptor: CBDescriptor
@@ -337,7 +337,7 @@ private class WriteDescriptorOperation: BasicOperation<Void> {
     }
 }
 
-private class ReadDescriptorOperation: BasicOperation<Any?> {
+private class ReadDescriptorOperation: BasicOperation<Any?>, @unchecked Sendable {
     let updateEventPublisher: AnyPublisher<(CBDescriptor, Error?), Never>
     let descriptor: CBDescriptor
 

--- a/Sources/iOS-BLE-Library/Utilities/CBManagerState.swift
+++ b/Sources/iOS-BLE-Library/Utilities/CBManagerState.swift
@@ -18,7 +18,7 @@ import Foundation
 
 @available(iOS 10.0, *)
 @available(macOS 10.13, *)
-extension CBManagerState: CustomDebugStringConvertible, CustomStringConvertible {
+extension CBManagerState: @retroactive CustomDebugStringConvertible, @retroactive CustomStringConvertible {
 
 	public var debugDescription: String {
 		return description


### PR DESCRIPTION
These are inherited Unchecked @Sendable(s), so it's not like we're altering any existing behaviour.