### PR TITLE
Cleanup of commented out function definition

### DIFF
--- a/Sources/iOS-BLE-Library/Peripheral/ReactivePeripheralDelegate.swift
+++ b/Sources/iOS-BLE-Library/Peripheral/ReactivePeripheralDelegate.swift
@@ -144,16 +144,7 @@ open class ReactivePeripheralDelegate: NSObject, CBPeripheralDelegate {
         discoveredServicesQueue.runNext()
 	}
 
-    /*
-	public func peripheral(
-		_ peripheral: CBPeripheral, didDiscoverIncludedServicesFor service: CBService,
-		error: Error?
-	) {
-		discoveredIncludedServicesSubject.send((service, service.includedServices, error))
-	}
-     */
-
-	// MARK: Discovering Characteristics and their Descriptors
+    // MARK: Discovering Characteristics and their Descriptors
 
 	open func peripheral(
 		_ peripheral: CBPeripheral, didDiscoverCharacteristicsFor service: CBService,


### PR DESCRIPTION
I think the function is implemented, so no need to track it in a comment.