### PR TITLE
Added CentralManager.isPoweredOn() async throws helper function

### DIFF
--- a/Sources/iOS-BLE-Library-Mock/Documentation.docc/CentralManager/CentralManager.md
+++ b/Sources/iOS-BLE-Library-Mock/Documentation.docc/CentralManager/CentralManager.md
@@ -8,6 +8,23 @@ The new instance of `CBCentralManager` can be created during initialization usin
 
 If you pass a central manager inside ``init(centralManager:)``, it should already have a delegate set. The delegate should be an instance of ``ReactiveCentralManagerDelegate``; otherwise, an error will be thrown.
 
+### Use of Central Manager
+
+As a wrapper around `CoreBluetooth`'s `CBCentralManager`, ``CentralManager`` cannot work unless the underlying `CBCentralManager` is in a valid state. Mainly, it must be `.poweredOn`. If you're familiar with BLE on Apple Platforms we're sure you have your own strategy to account for this. You can roll your own, listening to the ``stateChannel`` `PassthroughSubject`. We offer a quick solution for `async` environments in the form of ``CentralManager/isPoweredOn()``:
+
+```swift
+let centralManager: CentralManager = // init CentralManager
+
+do {
+   // Assumed async environment
+   await centralManager.isPoweredOn()
+
+   // Bluetooth available
+} catch let bleError {
+   // Bluetooth unavailable
+}
+```
+
 ### Channels
 
 Channels are used to pass through data from the `CBCentralManagerDelegate` methods.

--- a/Sources/iOS-BLE-Library/CentralManager/CentralManager.swift
+++ b/Sources/iOS-BLE-Library/CentralManager/CentralManager.swift
@@ -1,6 +1,6 @@
 //
-//  File.swift
-//
+//  CentralManager.swift
+//  iOS-BLE-Library
 //
 //  Created by Nick Kibysh on 18/04/2023.
 //
@@ -15,7 +15,10 @@ import CoreBluetoothMock
 //CG_END
 import Foundation
 
+// MARK: - Error
+
 extension CentralManager {
+    
 	public enum Err: Error {
 		case wrongManager
 		case badState(CBManagerState)
@@ -34,6 +37,8 @@ extension CentralManager {
 	}
 }
 
+// MARK: - Observer
+
 private class Observer: NSObject {
 	@objc dynamic private weak var cm: CBCentralManager?
 	private weak var publisher: CurrentValueSubject<Bool, Never>?
@@ -46,24 +51,23 @@ private class Observer: NSObject {
 	}
 
 	func setup() {
-		observation = observe(
-			\.cm?.isScanning,
-			options: [.old, .new],
-			changeHandler: { _, change in
-
-				change.newValue?.flatMap { [weak self] new in
-					self?.publisher?.send(new)
-				}
-			}
-		)
+		observation = observe(\.cm?.isScanning, options: [.old, .new],
+                               changeHandler: { _, change in
+            change.newValue?.flatMap { [weak self] new in
+                self?.publisher?.send(new)
+            }
+        })
 	}
 }
+
+// MARK: - CentralManager
 
 /// A Custom Central Manager class.
 /// 
 /// It wraps the standard CBCentralManager and has similar API. However, instead of using delegate, it uses publishers, thus bringing the reactive programming paradigm to the CoreBluetooth framework.
 public class CentralManager {
-	private let isScanningSubject = CurrentValueSubject<Bool, Never>(false)
+	
+    private let isScanningSubject = CurrentValueSubject<Bool, Never>(false)
 	private let killSwitchSubject = PassthroughSubject<Void, Never>()
 	private lazy var observer = Observer(cm: centralManager, publisher: isScanningSubject)
 
@@ -73,6 +77,8 @@ public class CentralManager {
 	/// The reactive delegate for the ``centralManager``.
 	public let centralManagerDelegate: ReactiveCentralManagerDelegate
 
+    // MARK: init
+    
 	/// Initializes a new instance of `CentralManager`.
 	/// - Parameters:
 	///   - centralManagerDelegate: The delegate for the reactive central manager. Default is `ReactiveCentralManagerDelegate()`.
@@ -112,6 +118,7 @@ public class CentralManager {
 }
 
 // MARK: Establishing or Canceling Connections with Peripherals
+
 extension CentralManager {
 	/// Establishes a connection with the specified peripheral.
 	/// - Parameters:
@@ -197,6 +204,7 @@ extension CentralManager {
 }
 
 // MARK: Retrieving Lists of Peripherals
+
 extension CentralManager {
 	#warning("check `connect` method")		
 	/// Returns a list of the peripherals connected to the system whose
@@ -228,6 +236,7 @@ extension CentralManager {
 }
 
 // MARK: Scanning or Stopping Scans of Peripherals
+
 extension CentralManager {
 	#warning("Question: Should we throw an error if the scan is already running?")
 	/// Initiates a scan for peripherals with the specified services.
@@ -278,6 +287,7 @@ extension CentralManager {
 }
 
 // MARK: Channels
+
 extension CentralManager {
 	/// A publisher that emits the state of the central manager.
 	public var stateChannel: AnyPublisher<CBManagerState, Never> {
@@ -309,4 +319,41 @@ extension CentralManager {
 		centralManagerDelegate.disconnectedPeripheralsSubject
 			.eraseToAnyPublisher()
 	}
+}
+
+// MARK: - State
+
+extension CentralManager {
+    
+    /**
+     Helper function to quickly ensure ``CentralManager`` is ready for use.
+     
+     As ``CentralManager`` is a wrapper around `CoreBluetooth`'s `CBCentralManager`, we must still abide by its requirements. The most important one being, to check whether its current state is valid in order to continue with proper BLE functions. As we know, BLE / `CoreBluetooth` might be unavailable for a variety of reasons, from the device's Bluetooth being turned off, to the current app not having Bluetooth permission, even up to hardware issues.
+     
+     - Tip: if you're setting up a ``CentralManager`` with a shared underlying `CBCentralManager` with other frameworks or areas of your app, and you'd like to retrieve a ``Peripheral`` that you're connected to via another "Manager" of some sort, waiting for ``isPoweredOn()`` before trying to find said ``Peripheral`` would be a good idea.
+     - Throws: if ``CentralManager`` cannot be used for Bluetooth. In other words, if ``stateChannel`` returns anything other than `CBManagerState.poweredOn`.
+     
+     Sample Usage:
+     ```swift
+     let centralManager: CentralManager = // init CentralManager
+     do {
+        // Assumed async environment
+        await centralManager.isPoweredOn()
+        // Bluetooth available
+     } catch let bleError {
+        // Bluetooth unavailable
+     }
+     */
+    public func isPoweredOn() async throws {
+        let currentState = try await stateChannel
+            // if state is .resetting, we should wait for it to
+            // return to .poweredOn or switch to Error.
+            .filter({ $0 != .resetting })
+            .firstValue
+        
+        guard currentState == .poweredOn else {
+            throw Err.badState(currentState)
+        }
+        return // System Ready / BLE Radio Available
+    }
 }

--- a/Sources/iOS-BLE-Library/Documentation.docc/CentralManager/CentralManager.md
+++ b/Sources/iOS-BLE-Library/Documentation.docc/CentralManager/CentralManager.md
@@ -8,6 +8,23 @@ The new instance of `CBCentralManager` can be created during initialization usin
 
 If you pass a central manager inside ``init(centralManager:)``, it should already have a delegate set. The delegate should be an instance of ``ReactiveCentralManagerDelegate``; otherwise, an error will be thrown.
 
+### Use of Central Manager
+
+As a wrapper around `CoreBluetooth`'s `CBCentralManager`, ``CentralManager`` cannot work unless the underlying `CBCentralManager` is in a valid state. Mainly, it must be `.poweredOn`. If you're familiar with BLE on Apple Platforms we're sure you have your own strategy to account for this. You can roll your own, listening to the ``stateChannel`` `PassthroughSubject`. We offer a quick solution for `async` environments in the form of ``CentralManager/isPoweredOn()``:
+
+```swift
+let centralManager: CentralManager = // init CentralManager
+
+do {
+   // Assumed async environment
+   await centralManager.isPoweredOn()
+
+   // Bluetooth available
+} catch let bleError {
+   // Bluetooth unavailable
+}
+```
+
 ### Channels
 
 Channels are used to pass through data from the `CBCentralManagerDelegate` methods.


### PR DESCRIPTION
CBCentralManager cannot be used unless it's .poweredOn. This helper function offers a quick and painless way to ensure Bluetooth code runs when allowed to do so.