### PR TITLE
Fix: Account for .unknown state in CentralManager .isPoweredOn()

### DIFF
--- a/Sources/iOS-BLE-Library-Mock/CentralManager/CentralManager.swift
+++ b/Sources/iOS-BLE-Library-Mock/CentralManager/CentralManager.swift
@@ -336,9 +336,9 @@ extension CentralManager {
      */
     public func isPoweredOn() async throws {
         let currentState = try await stateChannel
-            // if state is .resetting, we should wait for it to
-            // return to .poweredOn or switch to Error.
+            // Wait for a state that is not subject to change quickly.
             .filter({ $0 != .resetting })
+            .filter({ $0 != .unknown })
             .firstValue
         
         guard currentState == .poweredOn else {

--- a/Sources/iOS-BLE-Library/CentralManager/CentralManager.swift
+++ b/Sources/iOS-BLE-Library/CentralManager/CentralManager.swift
@@ -346,9 +346,9 @@ extension CentralManager {
      */
     public func isPoweredOn() async throws {
         let currentState = try await stateChannel
-            // if state is .resetting, we should wait for it to
-            // return to .poweredOn or switch to Error.
+            // Wait for a state that is not subject to change quickly.
             .filter({ $0 != .resetting })
+            .filter({ $0 != .unknown })
             .firstValue
         
         guard currentState == .poweredOn else {


### PR DESCRIPTION
In .unknown state, like .resetting, we need to wait a bit more.