### PR TITLE
Fix for incorrectly-filtered Read Operation Output

### DIFF
--- a/Sources/iOS-BLE-Library-Mock/Peripheral/Peripheral+Writer.swift
+++ b/Sources/iOS-BLE-Library-Mock/Peripheral/Peripheral+Writer.swift
@@ -10,7 +10,8 @@ import CoreBluetoothMock
 import Foundation
 
 extension Peripheral {
-	class OperationQueue {
+	
+    class OperationQueue {
 		let queue = Foundation.OperationQueue()
 		let peripheral: CBPeripheral
 
@@ -23,10 +24,7 @@ extension Peripheral {
 	class CharacteristicWriter: OperationQueue {
 		let writtenEventsPublisher: AnyPublisher<(CBCharacteristic, Error?), Never>
 
-		init(
-			writtenEventsPublisher: AnyPublisher<(CBCharacteristic, Error?), Never>,
-			peripheral: CBPeripheral
-		) {
+		init(writtenEventsPublisher: AnyPublisher<(CBCharacteristic, Error?), Never>, peripheral: CBPeripheral) {
 			self.writtenEventsPublisher = writtenEventsPublisher
 			super.init(peripheral: peripheral)
 		}
@@ -35,10 +33,7 @@ extension Peripheral {
 	class CharacteristicReader: OperationQueue {
 		let updateEventPublisher: AnyPublisher<(CBCharacteristic, Error?), Never>
 
-		init(
-			updateEventPublisher: AnyPublisher<(CBCharacteristic, Error?), Never>,
-			peripheral: CBPeripheral
-		) {
+		init(updateEventPublisher: AnyPublisher<(CBCharacteristic, Error?), Never>, peripheral: CBPeripheral) {
 			self.updateEventPublisher = updateEventPublisher
 			super.init(peripheral: peripheral)
 		}
@@ -47,10 +42,8 @@ extension Peripheral {
 	class DescriptorWriter: OperationQueue {
 		let writtenEventsPublisher: AnyPublisher<(CBDescriptor, Error?), Never>
 
-		init(
-			writtenEventsPublisher: AnyPublisher<(CBDescriptor, Error?), Never>,
-			peripheral: CBPeripheral
-		) {
+		init(writtenEventsPublisher: AnyPublisher<(CBDescriptor, Error?), Never>,
+             peripheral: CBPeripheral) {
 			self.writtenEventsPublisher = writtenEventsPublisher
 			super.init(peripheral: peripheral)
 		}
@@ -59,10 +52,8 @@ extension Peripheral {
 	class DescriptorReader: OperationQueue {
 		let updateEventsPublisher: AnyPublisher<(CBDescriptor, Error?), Never>
 
-		init(
-			updateEventsPublisher: AnyPublisher<(CBDescriptor, Error?), Never>,
-			peripheral: CBPeripheral
-		) {
+		init(updateEventsPublisher: AnyPublisher<(CBDescriptor, Error?), Never>,
+             peripheral: CBPeripheral) {
 			self.updateEventsPublisher = updateEventsPublisher
 			super.init(peripheral: peripheral)
 		}
@@ -70,7 +61,8 @@ extension Peripheral {
 }
 
 extension Peripheral.CharacteristicWriter {
-	func write(_ value: Data, to characteristic: CBCharacteristic) -> Future<Void, Error> {
+	
+    func write(_ value: Data, to characteristic: CBCharacteristic) -> Future<Void, Error> {
 		let operation = WriteCharacteristicOperation(
 			data: value,
 			writtenEventsPublisher: writtenEventsPublisher,
@@ -84,36 +76,35 @@ extension Peripheral.CharacteristicWriter {
 }
 
 extension Peripheral.CharacteristicReader {
-	func readValue(from characteristc: CBCharacteristic) -> Future<Data?, Error> {
+	
+    func readValue(from characteristc: CBCharacteristic) -> Future<Data?, Error> {
 		let operation = ReadCharacteristicOperation(
 			updateEventPublisher: updateEventPublisher,
 			characteristic: characteristc,
 			peripheral: peripheral
 		)
-
 		queue.addOperation(operation)
-
 		return operation.future
 	}
 }
 
 extension Peripheral.DescriptorWriter {
-	func write(_ value: Data, to dsecriptor: CBDescriptor) -> Future<Void, Error> {
+	
+    func write(_ value: Data, to dsecriptor: CBDescriptor) -> Future<Void, Error> {
 		let operation = WriteDescriptorOperation(
 			data: value,
 			writtenEventsPublisher: writtenEventsPublisher,
 			descriptor: dsecriptor,
 			peripheral: peripheral
 		)
-
 		queue.addOperation(operation)
-
 		return operation.future
 	}
 }
 
 extension Peripheral.DescriptorReader {
-	func readValue(from descriptor: CBDescriptor) -> Future<Any?, Error> {
+	
+    func readValue(from descriptor: CBDescriptor) -> Future<Any?, Error> {
 		let operation = ReadDescriptorOperation(
 			updateEventPublisher: updateEventsPublisher,
 			descriptor: descriptor,
@@ -125,6 +116,8 @@ extension Peripheral.DescriptorReader {
 		return operation.future
 	}
 }
+
+// MARK: - BasicOperation
 
 private class BasicOperation<T>: Operation, @unchecked Sendable {
 	let peripheral: CBPeripheral
@@ -176,6 +169,8 @@ private class BasicOperation<T>: Operation, @unchecked Sendable {
 	}
 }
 
+// MARK: - WriteCharacteristicOperation
+
 private class WriteCharacteristicOperation: BasicOperation<Void>, @unchecked Sendable {
 
 	let writtenEventsPublisher: AnyPublisher<(CBCharacteristic, Error?), Never>
@@ -183,10 +178,7 @@ private class WriteCharacteristicOperation: BasicOperation<Void>, @unchecked Sen
 
 	let data: Data
 
-	init(
-		data: Data, writtenEventsPublisher: AnyPublisher<(CBCharacteristic, Error?), Never>,
-		characteristic: CBCharacteristic, peripheral: CBPeripheral
-	) {
+	init(data: Data, writtenEventsPublisher: AnyPublisher<(CBCharacteristic, Error?), Never>, characteristic: CBCharacteristic, peripheral: CBPeripheral) {
 		self.data = data
 		self.writtenEventsPublisher = writtenEventsPublisher
 		self.characteristic = characteristic
@@ -233,14 +225,15 @@ private class WriteCharacteristicOperation: BasicOperation<Void>, @unchecked Sen
 	}
 }
 
+// MARK: - ReadCharacteristicOperation
+
 private class ReadCharacteristicOperation: BasicOperation<Data?>, @unchecked Sendable {
-	let updateEventPublisher: AnyPublisher<(CBCharacteristic, Error?), Never>
+	
+    let updateEventPublisher: AnyPublisher<(CBCharacteristic, Error?), Never>
 	let characteristic: CBCharacteristic
 
-	init(
-		updateEventPublisher: AnyPublisher<(CBCharacteristic, Error?), Never>,
-		characteristic: CBCharacteristic, peripheral: CBPeripheral
-	) {
+	init(updateEventPublisher: AnyPublisher<(CBCharacteristic, Error?), Never>,
+         characteristic: CBCharacteristic, peripheral: CBPeripheral) {
 		self.updateEventPublisher = updateEventPublisher
 		self.characteristic = characteristic
 		super.init(peripheral: peripheral)
@@ -257,31 +250,39 @@ private class ReadCharacteristicOperation: BasicOperation<Data?>, @unchecked Sen
 		}
 
 		self.cancelable = updateEventPublisher.share()
-			.filter {
-				$0.0.uuid == self.characteristic.uuid
-					&& $0.0.service?.uuid == self.characteristic.service?.uuid
+			.filter { [unowned self] eventCharacteristic, _ in
+                guard eventCharacteristic.uuid == characteristic.uuid else {
+                    return false
+                }
+                guard let eventService = eventCharacteristic.service,
+                      let targetService = characteristic.service else {
+                    return true
+                }
+				return eventService.uuid == targetService.uuid
 			}
 			.first()
-			.tryMap { v in
-				if let e = v.1 {
-					throw e
+			.tryMap { eventCharacteristic, error in
+				if let error {
+					throw error
 				} else {
-					return v.0.value
+					return eventCharacteristic.value
 				}
 			}
 			.sink { [unowned self] completion in
-				if case .failure(let e) = completion {
-					self.promise?(.failure(e))
+				if case .failure(let error) = completion {
+					promise?(.failure(error))
 				}
-				self.state = .finished
-			} receiveValue: { v in
-				self.promise?(.success(v))
+				state = .finished
+			} receiveValue: { [unowned self] data in
+				promise?(.success(data))
 			}
 
 		state = .executing
 		main()
 	}
 }
+
+// MARK: - WriteDescriptorOperation
 
 private class WriteDescriptorOperation: BasicOperation<Void>, @unchecked Sendable {
 
@@ -290,10 +291,7 @@ private class WriteDescriptorOperation: BasicOperation<Void>, @unchecked Sendabl
 
 	let data: Data
 
-	init(
-		data: Data, writtenEventsPublisher: AnyPublisher<(CBDescriptor, Error?), Never>,
-		descriptor: CBDescriptor, peripheral: CBPeripheral
-	) {
+	init(data: Data, writtenEventsPublisher: AnyPublisher<(CBDescriptor, Error?), Never>, descriptor: CBDescriptor, peripheral: CBPeripheral) {
 		self.data = data
 		self.writtenEventsPublisher = writtenEventsPublisher
 		self.descriptor = descriptor
@@ -345,14 +343,15 @@ private class WriteDescriptorOperation: BasicOperation<Void>, @unchecked Sendabl
 	}
 }
 
+// MARK: - ReadDescriptorOperation
+
 private class ReadDescriptorOperation: BasicOperation<Any?>, @unchecked Sendable {
-	let updateEventPublisher: AnyPublisher<(CBDescriptor, Error?), Never>
+	
+    let updateEventPublisher: AnyPublisher<(CBDescriptor, Error?), Never>
 	let descriptor: CBDescriptor
 
-	init(
-		updateEventPublisher: AnyPublisher<(CBDescriptor, Error?), Never>,
-		descriptor: CBDescriptor, peripheral: CBPeripheral
-	) {
+	init(updateEventPublisher: AnyPublisher<(CBDescriptor, Error?), Never>,
+         descriptor: CBDescriptor, peripheral: CBPeripheral) {
 		self.updateEventPublisher = updateEventPublisher
 		self.descriptor = descriptor
 		super.init(peripheral: peripheral)

--- a/Sources/iOS-BLE-Library-Mock/Peripheral/Peripheral.swift
+++ b/Sources/iOS-BLE-Library-Mock/Peripheral/Peripheral.swift
@@ -286,8 +286,10 @@ extension Peripheral {
 }
 
 // MARK: - Reading Characteristic and Descriptor Values
+
 extension Peripheral {
-	/// Read the value of a characteristic.
+	
+    /// Read the value of a characteristic.
 	///
 	/// - Parameter characteristic: The characteristic to read from.
 	/// - Returns: A future emitting the read data or an error.


### PR DESCRIPTION
Due to a failed comparison of a Characteristc's Service(s), the correct operation's output is filtered-out, so the rest of the Combine pipeline doesn't continue, and nothing ever happens.