### PR TITLE
Fix for peripheral.discoverServices(serviceUUIDs: nil) not returning if Service Discovery is empty

### DIFF
--- a/Sources/iOS-BLE-Library/Peripheral/Peripheral.swift
+++ b/Sources/iOS-BLE-Library/Peripheral/Peripheral.swift
@@ -185,12 +185,17 @@ extension Peripheral {
         
         return peripheralDelegate.discoveredServicesSubject
             .first(where: { $0.id == operationID })
-            .tryCompactMap { result throws -> [CBService]? in
+            .tryMap { result throws -> [CBService]? in
                 if let error = result.error {
                     throw error
                 } else {
                     return result.value
                 }
+            }
+            .map {
+                // No Services discovered, which is not an Error, is returned as nil.
+                // So here we transform it into nil array of Services.
+                $0 ?? []
             }
             .map { input -> [CBService] in
                 guard let serviceUUIDs else {


### PR DESCRIPTION
If there are no Services returned by the native CoreBluetooth callback, it is swallowed in the compactMap {} and then nothing is ever returned, so the 'await' never returns. This needs to be fixed / patched somewhere, I decided to do it here and to make it clear by breaking it out of the latter map which processes the received outcome.