### PR TITLE
Updated Package dependency URL

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -3,7 +3,7 @@
     {
       "identity" : "ios-corebluetooth-mock",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/NordicSemiconductor/IOS-CoreBluetooth-Mock.git",
+      "location" : "https://github.com/nordicsemi/IOS-CoreBluetooth-Mock.git",
       "state" : {
         "revision" : "5748c9e8b1750e0d7bc09243c099ff618f211cdf",
         "version" : "1.0.6"
@@ -21,7 +21,7 @@
     {
       "identity" : "swift-docc-symbolkit",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-docc-symbolkit",
+      "location" : "https://github.com/swiftlang/swift-docc-symbolkit",
       "state" : {
         "revision" : "b45d1f2ed151d057b54504d653e0da5552844e34",
         "version" : "1.0.0"

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         .library(name: "iOS-BLE-Library-Mock", targets: ["iOS-BLE-Library-Mock"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/NordicSemiconductor/IOS-CoreBluetooth-Mock.git",
+        .package(url: "https://github.com/nordicsemi/IOS-CoreBluetooth-Mock.git",
                  .upToNextMajor(from: "1.0.6")
         ),
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.5.0"),


### PR DESCRIPTION
Basically updated to the newer URL. This should solve Xcode warnings in other projects.